### PR TITLE
Update GEOSgcm to external FMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 5.25.0
+  VERSION 10.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.3
+tag = v1.0.7
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
@@ -34,6 +34,13 @@ required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
 tag = v1.1.6
+protocol = git
+
+[FMS]
+required = True
+repo_url = git@github.com:GEOS-ESM/FMS.git
+local_path = ./src/Shared/@GFDL_fms
+tag = geos/orphan/v1.0.0
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.7
+tag = v1.0.8
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.8
+tag = v1.0.9
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.7
+tag = v1.0.8
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.5
+tag = v1.0.7
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
@@ -34,6 +34,13 @@ required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
 tag = v1.1.6
+protocol = git
+
+[FMS]
+required = True
+repo_url = git@github.com:GEOS-ESM/FMS.git
+local_path = ./src/Shared/@GFDL_fms
+tag = geos/orphan/v1.0.0
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.0.8
+tag = v1.0.9
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,3 +1,4 @@
 /@GMAO_Shared
 /@MAPL
 /@NCEP_Shared
+/@GFDL_fms

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -3,3 +3,8 @@ esma_add_subdirectories (
   @GMAO_Shared
   @NCEP_Shared
   )
+
+# Special case - GFDL_fms is built twice with two
+# different precisions.
+add_subdirectory (@GFDL_fms GFDL_fms_r4)
+add_subdirectory (@GFDL_fms GFDL_fms_r8)


### PR DESCRIPTION
This update moves `GFDL_fms` from inside `@GMAO_Shared` to being parallel to it and `@MAPL`.

Also get new montage plot fixes from @lltakacs.

I tested this both in `Release` and `Debug` mode and they are zero-diff to `Develop.cfg` runs of last night (as hopes since @tclune just moved FMS and didn't change any source).