### PR TITLE
Update CPLFCST_Etc version to fix .git copy

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -69,7 +69,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/CPLFCST_Etc.git
 local_path = ./src/Applications/@CPLFCST_Etc
-tag = v1.0.0
+tag = v1.0.1
 protocol = git
 
 [externals_description]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -69,7 +69,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/CPLFCST_Etc.git
 local_path = ./src/Applications/@CPLFCST_Etc
-tag = v1.0.0
+tag = v1.0.1
 protocol = git
 
 [externals_description]


### PR DESCRIPTION
This is a dumb trivial fix but the CPLFCST_Etc CMake was copying its own `.git/` directory into its installation.