### PR TITLE
Add GSW-Fortran to Shared libraries

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -29,6 +29,13 @@ tag = v1.0.10
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
+[GSW-Fortran]
+required = True
+repo_url = git@github.com:JCSDA/GSW-Fortran.git
+local_path = ./src/Shared/@GSW-Fortran
+branch = develop
+protocol = git
+
 [MAPL]
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -32,7 +32,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 [GSW-Fortran]
 required = True
 repo_url = git@github.com:JCSDA/GSW-Fortran.git
-local_path = ./src/Shared/@GSW-Fortran
+local_path = ./src/Shared/@GSW
 branch = develop
 protocol = git
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v1.3.2
+tag = v1.3.3
 protocol = git
 
 [ESMA_cmake]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -29,6 +29,13 @@ tag = v1.0.10
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 
+[GSW-Fortran]
+required = True
+repo_url = git@github.com:JCSDA/GSW-Fortran.git
+local_path = ./src/Shared/@GSW-Fortran
+branch = develop
+protocol = git
+
 [MAPL]
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -32,7 +32,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 [GSW-Fortran]
 required = True
 repo_url = git@github.com:JCSDA/GSW-Fortran.git
-local_path = ./src/Shared/@GSW-Fortran
+local_path = ./src/Shared/@GSW
 branch = develop
 protocol = git
 

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -2,4 +2,4 @@
 /@MAPL
 /@NCEP_Shared
 /@GFDL_fms
-/@GSW-Fortran
+/@GSW

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -2,3 +2,4 @@
 /@MAPL
 /@NCEP_Shared
 /@GFDL_fms
+/@GSW-Fortran

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,8 +1,13 @@
+# GSW (ecbuild project) includes ecbuild_system; disable it!
+if( EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/@GSW )
+   set (gsw_ECBUILD_SYSTEM_INCLUDED TRUE)
+endif()
+
 esma_add_subdirectories (
   @MAPL
   @GMAO_Shared
   @NCEP_Shared
-  @GSW-Fortran
+  @GSW
   )
 
 # Special case - GFDL_fms is built twice with two

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -2,6 +2,7 @@ esma_add_subdirectories (
   @MAPL
   @GMAO_Shared
   @NCEP_Shared
+  @GSW-Fortran
   )
 
 # Special case - GFDL_fms is built twice with two


### PR DESCRIPTION
External library GSW-Fortran is required for MOM6.
This is ongoing work related to issue https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/70

Change-Id: I164d1be27fabb821986632ca332e3fb34e212b2a