### PR TITLE
Fixes #75. Rename GFDL_fms to fms. Update cmake

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -9,7 +9,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = v1.0.9
+tag = v1.0.10
 externals = Externals.cfg
 protocol = git
 
@@ -46,8 +46,8 @@ protocol = git
 [FMS]
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
-local_path = ./src/Shared/@GFDL_fms
-tag = geos/orphan/v1.0.1
+local_path = ./src/Shared/@FMS
+tag = geos/orphan/v1.0.2
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,5 +1,5 @@
 /@GMAO_Shared
 /@MAPL
 /@NCEP_Shared
-/@GFDL_fms
+/@FMS
 /@GSW

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -10,7 +10,7 @@ esma_add_subdirectories (
   @GSW
   )
 
-# Special case - GFDL_fms is built twice with two
+# Special case - FMS is built twice with two
 # different precisions.
-add_subdirectory (@GFDL_fms GFDL_fms_r4)
-add_subdirectory (@GFDL_fms GFDL_fms_r8)
+add_subdirectory (@FMS fms_r4)
+add_subdirectory (@FMS fms_r8)


### PR DESCRIPTION
This change is related to the general renaming of FMS. The external
moves from `@GFDL_fms` to `@FMS` and then renames all library references
from `GFDL_fms_rN` to `fms_rN`.

Also includes fixes to `@cmake`