### PR TITLE
Added OpenMP flags to FV3 build

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -54,7 +54,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSgcm_GridComp.git
 local_path = ./src/Components/@GEOSgcm_GridComp
-branch = features/aoloso/FV3_OpenMP_build
+branch = dev/aoloso/FV3_OpenMP_build
 protocol = git
 externals = Externals.cfg
 

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -54,7 +54,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/GEOSgcm_GridComp.git
 local_path = ./src/Components/@GEOSgcm_GridComp
-branch = develop
+branch = features/aoloso/FV3_OpenMP_build
 protocol = git
 externals = Externals.cfg
 


### PR DESCRIPTION
I added option to enable OpenMP flag for @FVdycoreCubed_GridComp and @fvdycore in their respective CMakeLists.txt and propagated the newly created branch dev/aoloso/FV3_OpenMP_build all the way to GEOSgcm level modifying ./src/Components/@GEOSgcm_GridComp/Externals.cfg, 
./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/Externals.cfg and Develop.cfg. 
The intent for usage is to add -DOPENMP_FV3=YES (or 1 or ON or TRUE or Y) to the make step when enabling OpenMP is desired for FV3 dyn core. 