### PR TITLE
Update to UMD_Etc v1.0.2

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -69,7 +69,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/UMD_Etc.git
 local_path = ./src/Applications/@UMD_Etc
-tag = v1.0.1
+tag = v1.0.2
 protocol = git
 
 [CPLFCST_Etc]


### PR DESCRIPTION
This is a small bug fix for using GNU compilers with Ninja. UMD_Etc has some Fortran code with comments that look like C block comments and it just confuses Ninja. As the C comments are in Fortran comments, I just edited the comments.