### PR TITLE
Update to ESMA_env v1.4.1

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v1.4.0
+tag = v1.4.1
 protocol = git
 
 [ESMA_cmake]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v1.4.0
+tag = v1.4.1
 protocol = git
 
 [ESMA_cmake]


### PR DESCRIPTION
This merely moves the `basedir` for NCCS to point to the
`$SHARE/gmao_ops` build.

Zero-diff in my testing (it built which is probably the best test).