### PR TITLE
Fixes #103. Updates GEOSgcm to FMS geos/2019.01.01

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -47,7 +47,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/orphan/v1.0.3
+tag = geos/2019.01.01
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -47,7 +47,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/orphan/v1.0.3
+tag = geos/2019.01.01
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/components.yaml
+++ b/components.yaml
@@ -43,8 +43,8 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: git@github.com:GEOS-ESM/FMS.git
-  tag: geos/orphan/v1.0.3
-  develop: geos/orphan
+  tag: geos/2019.01.01
+  develop: geos/master
 
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp


### PR DESCRIPTION
This moves GEOSgcm to tag `geos/2019.01.01` which is like NOAA version 2019.01.01 but with MAPL constants