### PR TITLE
Update to ESMA_env v2.0.1

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.0
+tag = v2.0.1
 protocol = git
 
 [ESMA_cmake]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.0
+tag = v2.0.1
 protocol = git
 
 [ESMA_cmake]

--- a/components.yaml
+++ b/components.yaml
@@ -1,7 +1,7 @@
 ESMA_env:
   local: ./@env
   remote: git@github.com:GEOS-ESM/ESMA_env.git
-  tag: v2.0.0
+  tag: v2.0.1
   develop: master
 
 ESMA_cmake:


### PR DESCRIPTION
This update should allow for easy transition between SLES11 and SLES12 as the `g5_modules` in ESMA_env v2.0.1 should detect which you are on and then select the right modules.