### PR TITLE
Update config.yml with new image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env:6.0.4
+      - image: gmao/geos-build-env-gcc-source:6.0.4
     working_directory: /root/project
     steps:
       - checkout
@@ -16,10 +16,6 @@ jobs:
             mepo clone
             mepo develop GEOSgcm_App GEOSgcm_GridComp
             mepo status
-      - run:
-          name: "Fix linker flags"
-          command: |
-            sed -i -e '$aset(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -Wl,--unresolved-symbols=ignore-all")' ./@cmake/GNU.cmake
       - run:
           name: "CMake"
           command: |


### PR DESCRIPTION
This update uses the `gmao/geos-build-env-gcc-source:6.0.4` image which seems to do better and doesn't need the weird sed/cmake hack.