### PR TITLE
Add mepo capability to parallel_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,27 @@ git clone git@github.com:GEOS-ESM/GEOSgcm.git
 
 If all you wish is to build the model, you can run `parallel_build.csh` from a head node. Doing so will checkout all the external repositories of the model and build it. When done, the resulting model build will be found in `build/` and the installation will be found in `install/` with setup scripts like `gcm_setup` and `fvsetup` in `install/bin`.
 
-#### Develop Version of GEOS
+#### Develop Version of GEOS GCM
 
 The user will notice two files in the main directory: `Externals.cfg` and `Develop.cfg`. The difference between these two is that `Externals.cfg` always refers to stable tested released subrepositories. The `Develop.cfg` points to the `develop` branch of `@GEOSgcm_GridComp` and `@GEOSgcm_App`. This is equivalent in the CVS days of the difference between a stable `Jason-X_Y` tag and the development `Jason-UNSTABLE` tag. In order to build the `Develop.cfg` version of the model with `parallel_build.csh` do:
 ```
 parallel_build.csh -develop
 ```
 
-#### Debug Version of GEOS
+#### Debug Version of GEOS GCM
 
 To obtain a debug version, you can run `parallel_build.csh -debug` which will build with debugging flags. This will build in `build-Debug/` and install into `install-Debug/`.
+
+#### Mepo Version of GEOS GCM
+
+GEOS GCM will soon be transitioning from using `checkout_externals` to
+using [`mepo`](https://github.com/GEOS-ESM/mepo), a GMAO-developed
+multi-repository management tool. If you wish to use it via
+`parallel_build.csh` you can run:
+```
+parallel_build.csh -mepo
+```
+along with any other flags you usually use.
 
 ---
 
@@ -65,16 +76,46 @@ To obtain a debug version, you can run `parallel_build.csh -debug` which will bu
 
 The steps detailed below are essentially those that `parallel_build.csh` performs for you. Either method should yield identical builds.
 
-##### Checkout externals
+#### Checkout externals
+
+Using the `checkout_externals` command to compose the model is done by:
+
 ```
 cd GEOSgcm
 checkout_externals
 ```
-###### Checking out develop 
+i###### Checking out develop 
 To use the `Develop.cfg` file, run:
 ```
 checkout_externals -e Develop.cfg
 ```
+
+#### Mepo
+
+To checkout the full model with the
+[`mepo`](https://github.com/GEOS-ESM/mepo) tool, you run:
+
+```
+mepo init
+mepo clone
+```
+
+The first command initializes the multi-repository and the second one
+clones and assembles all the sub-repositories according to
+`components.yaml`
+
+##### Checking out develop
+
+To get development branches of GEOS GCM with `mepo` is different. `mepo`
+itself knows (via `components.yaml`) what the development branch of each
+subrepository is. The equivalent of `Develop.cfg` for `mepo` is to
+checkout the development branches of GEOSgcm_GridComp and GEOSgcm_App:
+```
+mepo develop GEOSgcm_GridComp GEOSgcm_App
+```
+
+This must be done after `mepo clone` as it is running a git command in
+each sub-repository.
 
 #### Build the Model
 

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -21,9 +21,16 @@ setenv ESMADIR $srcdir
 set origargv = "$argv"
 
 setenv external ""
+setenv DEVELOP FALSE
+setenv USEMEPO FALSE
 while ($#argv)
    if ("$1" == "-develop") then
+      setenv DEVELOP TRUE
       setenv external "-e Develop.cfg"
+   endif
+
+   if ("$1" == "-mepo") then
+      setenv USEMEPO TRUE
    endif
 
    shift
@@ -36,8 +43,18 @@ if (! -d ${ESMADIR}/@env) then
       echo " Please run from a head node"
       exit 1
    else
-      echo " Running checkout_externals"
-      checkout_externals $external
+      if ( "$USEMEPO" == "TRUE") then
+         echo "Running mepo initialization"
+         mepo init
+         mepo clone
+         if ( "$DEVELOP" == "TRUE" ) then
+            echo "Checking out development branches of GEOSgcm_GridComp and GEOSgcm_App"
+            mepo develop GEOSgcm_GridComp GEOSgcm_App
+         endif
+      else
+         echo " Running checkout_externals"
+         checkout_externals $external
+      endif
    endif
 endif
 


### PR DESCRIPTION
This commit allows one to use `mepo` to checkout the model instead of
`checkout_externals`. To do so you run:
```
./parallel_build.csh -mepo
```