### PR TITLE
Update GEOSgcm to ESMA_env v2.0.2

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.1
+tag = v2.0.2
 protocol = git
 
 [ESMA_cmake]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.0.1
+tag = v2.0.2
 protocol = git
 
 [ESMA_cmake]

--- a/components.yaml
+++ b/components.yaml
@@ -1,7 +1,7 @@
 ESMA_env:
   local: ./@env
   remote: git@github.com:GEOS-ESM/ESMA_env.git
-  tag: v2.0.1
+  tag: v2.0.2
   develop: master
 
 ESMA_cmake:


### PR DESCRIPTION
This update moves the SLES 12 setup of GEOSgcm to use Intel MPI 19.1 on SLES 12. Testing shows this to be zero-diff to runs on SLES11 as the compiler is not different