### PR TITLE
Update components.yaml env and cmake aliases

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,10 +1,10 @@
-ESMA_env:
+env:
   local: ./@env
   remote: git@github.com:GEOS-ESM/ESMA_env.git
   tag: v2.0.2
   develop: master
 
-ESMA_cmake:
+cmake:
   local: ./@cmake
   remote: git@github.com:GEOS-ESM/ESMA_cmake.git
   tag: v2.1.2


### PR DESCRIPTION
Change the "mepo names" for ESMA_env and ESMA_cmake. They were the only major repos whose mepo names weren't the same as their (non-@) directory names. E.g, doing this:
```
mepo commit env cmake
```
is more intuitive than:
```
mepo commit ESMA_env ESMA_cmake
```