### PR TITLE
Uptick to MAPL v2.0.4

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = v2.0.3
+tag = v2.0.4
 protocol = git
 
 [FMS]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = v2.0.3
+tag = v2.0.4
 protocol = git
 
 [FMS]

--- a/components.yaml
+++ b/components.yaml
@@ -37,7 +37,7 @@ GSW-Fortran:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.0.3
+  tag: v2.0.4
   develop: develop
 
 FMS:


### PR DESCRIPTION
update to MAPL version v2.0.4, fixes a bug causing History to crash in certain situations has exposed by coupled model.