### PR TITLE
Sparse out Pilgrim, FV, ARIES

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -50,6 +50,7 @@ local_path = ./src/Components/@GEOSgcm_GridComp
 branch = develop
 protocol = git
 externals = Externals.cfg
+sparse = ../../../config/GEOSgcm_GridComp.sparse
 
 [GEOSgcm_App]
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -50,6 +50,7 @@ local_path = ./src/Components/@GEOSgcm_GridComp
 tag = v1.8.6
 protocol = git
 externals = Externals.cfg
+sparse = ../../../config/GEOSgcm_GridComp.sparse
 
 [GEOSgcm_App]
 required = True

--- a/components.yaml
+++ b/components.yaml
@@ -45,6 +45,7 @@ GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
   tag: v1.8.6
+  sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
 FVdycoreCubed_GridComp:

--- a/config/GEOSgcm_GridComp.sparse
+++ b/config/GEOSgcm_GridComp.sparse
@@ -1,0 +1,3 @@
+/*
+!/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/ARIESg3_GridComp
+!/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycore_GridComp

--- a/config/GMAO_Shared.sparse
+++ b/config/GMAO_Shared.sparse
@@ -6,3 +6,4 @@
 !/GEOS_Pert
 !/arpack
 !/pnagpack
+!/GMAO_pilgrim


### PR DESCRIPTION
The FV and ARIES dynamical cores are essentially unmaintained at this point in the GCM. This PR sparses out:

* ARIESg3_GridComp
* FVdycore_GridComp

from GEOSgcm_GridComp (they aren't checked out, so therefore aren't built). At the same time, we sparse out:

* GMAO_pilgrim

from GMAO_Shared repo as it is used by these two Gridded Components (and only these two).

Note that for now we just sparse from GCM as I am not sure if the ADAS (or pert or whatever!) still needs Pilgrim, so I'm not removing anything. I think we could be safe removing the two dynamical cores, but Pilgrim is a library that might be used in unexpected ways.