### PR TITLE
Update repos and rename master->main

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.02
+tag = geos/2019.01.01
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.1.5
+tag = v2.1.6
 protocol = git
 
 [ESMA_cmake]
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.01
+tag = geos/2019.01.02
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.02
+tag = geos/2019.01.01
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = v2.1.5
+tag = v2.1.6
 protocol = git
 
 [ESMA_cmake]
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.01
+tag = geos/2019.01.02
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/components.yaml
+++ b/components.yaml
@@ -38,7 +38,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02
+  tag: geos/2019.01.01
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -1,8 +1,8 @@
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v2.1.5
-  develop: master
+  tag: v2.1.6
+  develop: main
 
 cmake:
   local: ./@cmake
@@ -20,14 +20,14 @@ NCEP_Shared:
   remote: ../NCEP_Shared.git
   tag: v1.0.0
   sparse: ./config/NCEP_Shared.sparse
-  develop: master
+  develop: main
 
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
   tag: v1.1.4
   sparse: ./config/GMAO_Shared.sparse
-  develop: master
+  develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
@@ -38,7 +38,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.01
+  tag: geos/2019.01.02
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:
@@ -50,13 +50,13 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.1.1
+  tag: v1.1.3
   develop: develop
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.1.0
+  tag: geos/v1.1.2
   develop: geos/develop
 
 GEOSchem_GridComp:
@@ -81,10 +81,10 @@ UMD_Etc:
   local: ./src/Applications/@UMD_Etc
   remote: ../UMD_Etc.git
   tag: v1.0.3
-  develop: master
+  develop: main
 
 CPLFCST_Etc:
   local: ./src/Applications/@CPLFCST_Etc
   remote: ../CPLFCST_Etc.git
   tag: v1.0.1
-  develop: master
+  develop: main


### PR DESCRIPTION
This update changes:

* Update `master` -> `main`
  * This is in the repos whose `develop` branch is actually `main`
* Update to ESMA_env v2.1.6
  * Minor update to allow for capturing build modules
* ~~Update to FMS geos/2019.01.02~~
  * ~~Update for JEDI compatibility~~
* Update to FVdycoreCubed_GridComp v1.1.3 and GFDL_atmos_cubed_sphere v1.1.2
  * Support for non-72-level runs

ETA: I removed the FMS update as that should be tested more thoroughly with MOM, et al