### PR TITLE
Feature/wjamieson/hemco refactor

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
   remote: ../HEMCO.git
-  branch: master
+  branch: feature/wjamieson/GMAO_HEMCO_GridComp_updates
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -67,8 +67,7 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
   remote: ../HEMCO.git
-  tag: GEOS/v0.0.1
-  # branch: feature/wjamieson/GMAO_HEMCO_GridComp_updates
+  tag: GEOS/v1.0.0
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
   remote: ../HEMCO.git
-  tag: GEOS_12.8
+  branch: master
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -62,8 +62,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.3.5
-  develop: develop
+  branch: feature/wjamieson/HEMCO_refactor
 
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
   remote: ../HEMCO.git
-  tag: GEOS/v1.0.0
+  tag: geos/v1.0.1
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -65,6 +65,11 @@ GEOSchem_GridComp:
   tag: v1.3.5
   develop: develop
 
+HEMCO:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
+  remote: ../HEMCO.git
+  tag: GEOS_12.8
+
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
   remote: ../MOM5.git

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,8 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@HEMCO_GridComp
   remote: ../HEMCO.git
-  branch: feature/wjamieson/GMAO_HEMCO_GridComp_updates
+  tag: GEOS/v0.0.1
+  # branch: feature/wjamieson/GMAO_HEMCO_GridComp_updates
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom


### PR DESCRIPTION
This refactor allows for the use of the HEMCO from our new HEMCO fork: https://github.com/GEOS-ESM/HEMCO. These changes appear to be zero diff with both the HEMCO enabled and HEMCO disabled when used in the GCM. 

This PR is part a mulit-repo PR. There will be a related PR on the GEOSchem_GridComp.