### PR TITLE
Update FMS to geos/2019.01.02+noaff

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.02
+tag = geos/2019.01.02+noaff
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -40,7 +40,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/FMS.git
 local_path = ./src/Shared/@FMS
-tag = geos/2019.01.02
+tag = geos/2019.01.02+noaff
 protocol = git
 
 [GEOSgcm_GridComp]

--- a/components.yaml
+++ b/components.yaml
@@ -38,7 +38,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02
+  tag: geos/2019.01.02+noaff
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This updates FMS in GEOSgcm to the [geos/2019.01.02+noaff](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff) release. This has been tested as zero-diff with AMIP, MOM5, and MOM6.

The main impetus is to allow building with newer Linux OSs like Fedora by not building the FMS affinity code that is unused in GEOS.