### PR TITLE
Update to FV3 GC v1.2.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -51,7 +51,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.1.4
+  tag: v1.2.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This zero-diff change updates FV3 GC to v1.2.0 which brings in the `fv3_setup` and `fv3.j` scripts. A companion to https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/319