### PR TITLE
Use Ubuntu20 GCC10 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,8 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: gmao/geos-build-env-gcc-source:6.0.13-openmpi_4.0.3-gcc_9.3.0
+      - image: gmao/ubuntu20-geos-env-mkl:6.0.13-openmpi_4.0.4-gcc_10.2.0
     resource_class: xlarge
-    working_directory: /root/project
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This updates the GEOSgcm CI image to use Ubuntu 10 and GCC 10