### PR TITLE
Update to GMAO_Shared v1.1.8

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.1.7
+tag = v1.1.8
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ sparse = ../../../config/NCEP_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/GMAO_Shared.git
 local_path = ./src/Shared/@GMAO_Shared
-tag = v1.1.7
+tag = v1.1.8
 protocol = git
 sparse = ../../../config/GMAO_Shared.sparse
 

--- a/components.yaml
+++ b/components.yaml
@@ -25,7 +25,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.1.7
+  tag: v1.1.8
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 


### PR DESCRIPTION
This PR updates GMAO_Shared to v1.1.8. [This release](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.1.8) was to allow Intel 19 to use CICE. Zero-diff.