### PR TITLE
Update components to monitor fixture

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,3 +1,7 @@
+GEOSgcm:
+  fixture: true
+  develop: main
+
 env:
   local: ./@env
   remote: ../ESMA_env.git


### PR DESCRIPTION
This PR is to add the ability for mepo to "see the fixture" by adding three lines to `components.yaml`.