### PR TITLE
Update CHANGELOG for 10.16.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [10.16.3] - 2020-11-02
+
+### Zero-diff to previous release: YES
+
+### Restart Changes: NO
+
+Changes include:
+
+1. Added fixture section to `components.yaml`
+
 ## [10.16.2] - 2020-10-28
 
 ### Zero-diff to previous release: YES for default catchment, NO for CatchmentCN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 10.16.2
+  VERSION 10.16.3
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
Advance `CHANGELOG.md` to make a tagged release with mepo-fixture addition in `components.yaml`