### PR TITLE
Update to MAPL 2.3.6

### DIFF
--- a/Develop.cfg
+++ b/Develop.cfg
@@ -33,7 +33,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = v2.3.4
+tag = v2.3.6
 protocol = git
 
 [FMS]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -33,7 +33,7 @@ sparse = ../../../config/GMAO_Shared.sparse
 required = True
 repo_url = git@github.com:GEOS-ESM/MAPL.git
 local_path = ./src/Shared/@MAPL
-tag = v2.3.4
+tag = v2.3.6
 protocol = git
 
 [FMS]

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.3.4
+  tag: v2.3.6
   develop: develop
 
 FMS:


### PR DESCRIPTION
Pulls in some bugfixes in MAPL since 2.3.4:
## [2.3.6] - 2020-11-12

### Added

- Added an external grid and clock setter (for NUOPC).

### Fixed

- Fixed logic to allow proper termination of all imports except those specified

## [2.3.5] - 2020-11-06

### Added

- Added fixture entry to `components.yaml` (requires mepo v1.23.0 or higher)

### Fixed

- Fixed integer overflow in memutils for big memory systems
- Fix bug with segment alarm when processing a monthly mean collection
