### PR TITLE
Fix bug in parallel_build

### DIFF
--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -38,7 +38,11 @@ end
 
 if (! -d ${ESMADIR}/@env) then
    if ($?PBS_JOBID || $?SLURM_JOBID) then
-      echo " checkout_externals must be run!"
+      if ( "$USEMEPO" == "TRUE") then
+         echo " mepo clone must be run!"
+      else
+         echo " checkout_externals must be run!"
+      endif
       echo " This requires internet access but you are on a compute node"
       echo " Please run from a head node"
       exit 1
@@ -54,6 +58,13 @@ if (! -d ${ESMADIR}/@env) then
       else
          echo " Running checkout_externals"
          checkout_externals $external
+      endif
+   endif
+else
+   if ( "$USEMEPO" == "TRUE") then
+      if ( "$DEVELOP" == "TRUE" ) then
+         echo "Checking out development branches of GEOSgcm_GridComp and GEOSgcm_App"
+         mepo develop GEOSgcm_GridComp GEOSgcm_App
       endif
    endif
 endif


### PR DESCRIPTION
This was found by @sanAkel. The issue is that in `parallel_build.csh`, if `mepo init` and `clone` have already run, then the `-develop` flag is ignored. We don't want that, so instead we need to run `mepo develop`