### PR TITLE
add NCEP_bufr to turn on BUILD_SHARED_LIBS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ jobs:
             mepo init
             mepo clone
             mepo develop GEOSgcm_App GEOSgcm_GridComp
+            if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "main" ]
+            then
+               mepo checkout-if-exists ${CIRCLE_BRANCH}
+            fi
             mepo status
       - run:
           name: "CMake"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
             mepo init
             mepo clone
             mepo develop GEOSgcm_App GEOSgcm_GridComp
+            mepo status
+      - run:
+          name: "Mepo checkout-if-exists"
+          command: |
+            echo "${CIRCLE_BRANCH}"
             if [ "${CIRCLE_BRANCH}" != "develop" ] && [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "main" ]
             then
                mepo checkout-if-exists ${CIRCLE_BRANCH}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -42,6 +42,12 @@ jobs:
           mepo status
           mepo develop GEOSgcm_GridComp GEOSgcm_App
           mepo status
+      - name: Update other branches
+        if:
+          "!contains('refs/heads/main,refs/heads/develop', github.ref)"
+        run: |
+          mepo checkout-if-exists ${GITHUB_HEAD_REF}
+          mepo status
       - name: CMake
         run: |
           mkdir build

--- a/Develop.cfg
+++ b/Develop.cfg
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/NCEP_Shared.git
 local_path = ./src/Shared/@NCEP_Shared
-tag = v1.1.0
+tag = v1.1.1
 protocol = git
 sparse = ../../../config/NCEP_Shared.sparse
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -17,7 +17,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/NCEP_Shared.git
 local_path = ./src/Shared/@NCEP_Shared
-tag = v1.1.0
+tag = v1.1.1
 protocol = git
 sparse = ../../../config/NCEP_Shared.sparse
 

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared
   remote: ../NCEP_Shared.git
-  tag: v1.1.0
+  tag: v1.1.1
   sparse: ./config/NCEP_Shared.sparse
   develop: main
 

--- a/config/NCEP_Shared.sparse
+++ b/config/NCEP_Shared.sparse
@@ -1,6 +1,7 @@
 !/*
 /NCEP_sp
 /NCEP_w3
+/NCEP_bufr
 /NCEP_bacio
 /NCEP_sfcio
 /NCEP_sigio


### PR DESCRIPTION
This is the 'same' as https://github.com/GEOS-ESM/GEOSgcm/pull/224 from @weiyuan-jiang but with a renamed branch to (hopefully) allow CI to work.

This depends on https://github.com/GEOS-ESM/NCEP_Shared/pull/15 being tagged and released.