### PR TITLE
Update FVdycoreCubed_GridComp to v1.2.7

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.6
+  tag: v1.2.7
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This is a nigh-trivial update that fixes the `fv3.j` script to handle GEOS shared object libraries. That's it!