### PR TITLE
Update to FVdycoreCubed_GridComp v1.2.8

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.7
+  tag: v1.2.8
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This is a very minor update to the FVdycoreCubed_GridComp with zero-diff minimal changes [two lines in CubeGridPrototype.F90](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/compare/v1.2.7...v1.2.8).