### PR TITLE
Update to ESMA_env v3.1.3 [skip ci]

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.1.2
+  tag: v3.1.3
   develop: main
 
 cmake:


### PR DESCRIPTION
This updates to ESMA_env v3.1.3 which moves from Baselibs 6.0.22 to 6.0.27 which is a few minor library updates and some build system fixes:

This PR updates to Baselibs 6.0.27 which is a minor update to the current 6.0.22. The differences were mainly in the build system, though an important update is the yaFyaml for some work being done in MAPL.

## [6.0.27] - 2020-12-21

### Fixed

- Use of ifort at NAS was broken by changes to make the GNU Make
  system more robust
- HDF5 at NCCS with MPT requires an extra flag to compile

## [6.0.26] - 2020-12-09

### Updates

* cURL 7.74.0
* yaFyaml v0.4.2

### Fixed

* Fixes for GitHub Actions

## [6.0.25] - 2020-12-08

### Updates

* NCO 4.9.6

### Fixed

* Add patch for using antlr2 GitHub as it seems to have a bug. The patch
  makes it match the previous tarball

### Changed

* Moved to use antlr2 from https://github.com/nco/antlr2 as the download
  link broke
* Disabled the Java, Python, and C# builds for antlr2 as unneeded for
  NCO/ncap2

## [6.0.24] - 2020-11-25

### Fixed

- Explicitly turn off nghttp2 and nghttp3 support in cURL. It can
  sometimes find it in a Brew installation, but that could lead to
  linking in Brew includes and libraries.
- Fixed bug with using clang as C compiler
- Updated GitHub Actions workflow with new build image and fixed issues
  with build

### Changed

- Turned off default ESMPy build on Darwin with `esmf.install` due to
  odd RPATH issues. ESMPy can be built separately if needed.

## [6.0.23] - 2020-11-25

### Fixed

- GNU Make system reworked to be more generic. Older system assumed
  modules, `CC`, `FC`, etc were defined like at NCCS
