### PR TITLE
Don't run Github CI for unneeded changes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,6 +3,11 @@ name: Build Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    # Do not run if the only files changed cannot affect the build
+    paths-ignore:
+      - "**.md"
+      - "ChangeLog-PreJason.txt"
+      - "parallel_build.csh"
 
 jobs:
   build_gcm:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,6 +8,9 @@ on:
       - "**.md"
       - "ChangeLog-PreJason.txt"
       - "parallel_build.csh"
+      - ".github/CODEOWNERS"
+      - ".codebuild/**"
+      - ".circleci/**"
 
 jobs:
   build_gcm:


### PR DESCRIPTION
This is an attempt to not run CI if only, say, a markdown file is changed which can't affect the build anyway!