### PR TITLE
Update to ESMA_cmake v3.3.6

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.5
+  tag: v3.3.6
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This is a minor update to ESMA_cmake to v3.3.6 which adds the ability to try and detect if you are on AMD or Intel chips. Mainly used for testing at NAS, but should be zero-diff. (The only way to trigger the code is to actually *be* on an AMD machine)