### PR TITLE
Update to MAPL 2.6.2

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.0
+  tag: v2.6.1
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.1
+  tag: v2.6.2
   develop: develop
 
 FMS:


### PR DESCRIPTION
This is a patch update to MAPL. MAPL 2.6.1 was mainly build systems outside of NASA. MAPL 2.6.2  has updates for the ongoing DSO work (see https://github.com/GEOS-ESM/GEOSgcm_App/pull/204 and https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/377)