### PR TITLE
Update to FMS geos/2019.01.02+noaff.4

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.3
+  tag: geos/2019.01.02+noaff.4
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This update is a zero-diff change to FMS which builds it as shared object library.