### PR TITLE
Update to GEOSchem_GridComp v1.4.2

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.4.1
+  tag: v1.4.2
   develop: develop
 
 mom:


### PR DESCRIPTION
Thanks to @mmanyin, we have a new version of Chem GridComp. [As stated in the release](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.4.2), it is zero-diff for "usual" chem and I did some tests at C24 and both actual and climatological GOCART runs are zero-diff. 🥳 