### PR TITLE
Moving GOCART legacy to be sourced from GOCART repository. 

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.4.2
+  tag: v1.4.4
   develop: develop
 
 GOCART:

--- a/components.yaml
+++ b/components.yaml
@@ -73,7 +73,7 @@ GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
   sparse: ./config/GOCART.sparse
-  tag: v1.0.0-beta
+  tag: v1.0.0-beta.1
   develop: develop
 
 mom:

--- a/components.yaml
+++ b/components.yaml
@@ -69,9 +69,9 @@ GEOSchem_GridComp:
   remote: ../GEOSchem_GridComp.git
   branch: feature/wjamieson/GOCART_legacy_changes
 
-GOCART_GridComp:
-  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART_GridComp
-  remote: ../GOCART
+GOCART:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
+  remote: ../GOCART.git
   sparse: ./config/GOCART.sparse
   tag: v1.0.0-beta
   develop: develop

--- a/components.yaml
+++ b/components.yaml
@@ -73,7 +73,8 @@ GOCART_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART_GridComp
   remote: ../GOCART
   sparse: ./config/GOCART.sparse
-  branch: feature/wjamieson/GOCART_legacy_changes
+  tag: v1.0.0-beta
+  develop: develop
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  branch: feature/wjamieson/GOCART_legacy_changes
+  tag: v1.4.2
   develop: develop
 
 GOCART:

--- a/components.yaml
+++ b/components.yaml
@@ -67,8 +67,13 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.4.1
-  develop: develop
+  branch: feature/wjamieson/GOCART_legacy_changes
+
+GOCART_GridComp:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART_GridComp
+  remote: ../GOCART
+  sparse: ./config/GOCART.sparse
+  branch: feature/wjamieson/GOCART_legacy_changes
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom

--- a/components.yaml
+++ b/components.yaml
@@ -74,7 +74,7 @@ GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
   sparse: ./config/GOCART.sparse
-  tag: v1.0.0-beta.1
+  tag: v1.0.0
   develop: develop
 
 mom:

--- a/config/GOCART.sparse
+++ b/config/GOCART.sparse
@@ -1,0 +1,9 @@
+
+/*
+!/CCPP
+!/config
+!/ESMF/Aerosol_GridComp
+!/ESMF/Apps
+!/ESMF/NUOPC
+!/ESMF/Shared/Chem_Shared
+!/ESMF/Shared/Chem_Base

--- a/config/GOCART.sparse
+++ b/config/GOCART.sparse
@@ -4,6 +4,7 @@
 !/config
 !/ESMF/Aerosol_GridComp
 !/ESMF/Apps
+!/ESMF/GOCART2G_GridComp
 !/ESMF/NUOPC
 !/ESMF/Shared/Chem_Shared
 !/ESMF/Shared/Chem_Base


### PR DESCRIPTION
This is part of a multi-repository pull request to move GOCART legacy's source code from the `GEOSchem_GridComp` repository to the `GOCART` repository. All of the GOCART code remain's untouched, aside from moving it to a slightly different directory location and accompanying cmake changes.

The related pull request is [#115](https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/115#issue-578785185) in the `GEOSchem_GridComp` repository. Note that once the `GEOSchem_GridComp` PR has been accepted, the components.yaml file of this PR will need to be updated to new tag of the `GEOSchem_GridComp`.

I have tested this change by running a C12 experiment for 1 day and have found the results to be zero diff.