### PR TITLE
Use CMake to ignore build and install directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 /@cmake/
 /@modules/
 /@env/
-/BUILD/
-/build*/
-/install*/
 /.mepo/
 parallel_build.o*
 log.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,16 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 add_subdirectory (@env)
 add_subdirectory (src)
 
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+
+


### PR DESCRIPTION
Based on lessons learned in https://github.com/GEOS-ESM/MAPL/pull/718 we can use CMake itself to ignore any build or install directories. 