### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ make -jN install
 ```
 where `N` is the number of parallel processes. On discover head nodes, this should only be as high as 2 due to limits on the head nodes. On a compute node, you can set `N` has high as you like, though 8-12 is about the limit of parallelism in our model's make system.
 
-### Run the AGCM
+### Run the GCM
 
 Once the model has built successfully, you will have an `install/` directory in your checkout. To run `gcm_setup` go to the `install/bin/` directory and run it there:
 ```


### PR DESCRIPTION
The header `Run the GCM` needs to reflect the fact that `gcm_setup` sets up not only `AGCM` 

**Note:**
This same issue exists here (https://github.com/GEOS-ESM/GEOSadas/pull/56), may need the same in _other_ repos as well.