### PR TITLE
Update to ESMA_cmake v3.3.7

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.6
+  tag: v3.3.7
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates ESMA_cmake v3.3.7. All this does is fix flags when compiling with GNU on Graviton2 chips at AWS. It is *very* zero-diff. 😄 