### PR TITLE
Update MOM6 to latest NOAA code

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -11,6 +11,7 @@ phases:
   pre_build:
     commands:
       - mepo clone
+      - mepo status
       - mepo develop GEOSgcm_App GEOSgcm_GridComp
       - mepo status
     finally:

--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -11,9 +11,8 @@ phases:
   pre_build:
     commands:
       - mepo clone
-      - mepo status
       - mepo develop GEOSgcm_App GEOSgcm_GridComp
-      - mepo status
+      #- mepo status
     finally:
       - echo "Mepo clone external repos" 
   # This phase builds it

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,10 +23,6 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     env:
-      LANGUAGE: en_US.UTF-8
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
-      LC_TYPE: en_US.UTF-8 
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
       OMPI_MCA_btl_vader_single_copy_mechanism: none

--- a/components.yaml
+++ b/components.yaml
@@ -80,7 +80,7 @@ mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
   tag: geos/v2.0.0
-  develop: geos
+  develop: dev/gfdl
   recurse_submodules: True
 
 GEOSgcm_App:

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,8 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.5
+  #tag: geos/2019.01.02+noaff.5
+  branch: feature/mathomp4/affinity-fix
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -42,8 +42,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  #tag: geos/2019.01.02+noaff.5
-  branch: feature/mathomp4/affinity-fix
+  tag: geos/2019.01.02+noaff.6
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  branch: feature/sanAkel/test_PR_gfdl-fms2
+  tag: v1.11.6
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 

--- a/components.yaml
+++ b/components.yaml
@@ -42,13 +42,13 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.4
+  tag: geos/2019.01.02+noaff.5
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.11.5
+  branch: feature/sanAkel/test_PR_gfdl-fms2
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
@@ -79,7 +79,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v1.1.0
+  tag: geos/v2.0.0
   develop: geos
   recurse_submodules: True
 


### PR DESCRIPTION
This PR is really from @sanAkel and is updates needed to advance MOM6 in GEOS. It includes updates:

- FMS to `geos/2019.01.02+noaff.6` (zero-diff for AMIP and Coupled)
- MOM6 to `geos/v2.0.0` (zero-diff for Coupled)
- GEOSgcm_GridComp to *BRANCH* `feature/sanAkel/test_PR_gfdl-fms2` (see PR https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/416)

Of course, this latter one will be a *tag* of GEOSgcm_GridComp when all is well. 
