### PR TITLE
Update to GEOSchem_GridComp v1.4.3

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.4.2
+  tag: v1.4.3
   develop: develop
 
 mom:


### PR DESCRIPTION
I know we have #257 in the wings, but in case testing for that might take a while, here is a PR for an update to GEOSchem_GridComp v1.4.3. This is a (trivially) zero-diff update from @mmanyin that essentially was a code cleanup on v1.4.2:
https://github.com/GEOS-ESM/GEOSchem_GridComp/compare/v1.4.2...main

Removed some comments and cleaned up some prints.