### PR TITLE
Try to fix AWS Codebuild

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -12,7 +12,7 @@ phases:
     commands:
       - mepo clone
       - mepo develop GEOSgcm_App GEOSgcm_GridComp
-      - mepo status
+      #- mepo status
     finally:
       - echo "Mepo clone external repos" 
   # This phase builds it


### PR DESCRIPTION
For some reason `mepo status` seems to fail on AWS Codebuild. So, well, don't run that?