### PR TITLE
Update to MAPL 2.6.4

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.3
+  tag: v2.6.4
   develop: develop
 
 FMS:


### PR DESCRIPTION
This is needed as MAPL 2.6.4 has a bugfix for running GEOS on macOS with Intel 2021.

Minor update and zero-diff.