### PR TITLE
Switch to MOM6 as of Apr-05-2021

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -86,7 +86,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v2.0.0
+  tag: geos/v2.0.1
   develop: dev/gfdl
   recurse_submodules: True
 


### PR DESCRIPTION
Use (latest) MOM6 as of 04/05/2021. 
It includes a bug fix from GEOS side of things for [stress halo-exchange](https://github.com/NOAA-GFDL/MOM6/pull/1356)

@sdrabenh please note: 
- This is a zero-diff change (simply because we do regression testing on _certain_ layouts only in `gcm_regress.j`).
- Of course, only impacts answers with the coupled model, and specifically MOM6 coupled model.