### PR TITLE
Update to ESMA_env v3.2.0 (ESMF 8.1.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gcc-build-env:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.0.27-openmpi_4.0.5-gcc_10.2.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.0.27-openmpi_4.0.5-gcc_10.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.1.4
+  tag: v3.2.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This update moves GEOSgcm to use [ESMA_env v3.2.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.2.0). The main thrust of this is to move GEOS to use ESMF 8.1.0 which is needed for MAPL development.

All testing I have done has shown it zero-diff to GEOSgcm with ESMF 8.0.1. Tests were run from C12 to C720 as well as Replay and MOM6. @biljanaorescanin also tested GEOSldas and found it was zero-diff as well.

But [ESMF notes that there is a change some regridding could be non-zero-diff](https://github.com/esmf-org/esmf/releases/tag/ESMF_8_1_0). 

Thus why I'm not sure how to label this. I am fairly certain it's zero-diff, but perhaps this PR should be merged into GEOSgcm as a release in-and-of-itself. Just to let us be able to track back to ESMF change if needed? 