### PR TITLE
Update to ESMA_cmake v3.3.9, fvdycore v1.1.6, FV3 GC v1.2.12

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.7
+  tag: v3.3.8
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.11
+  tag: v1.2.12
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.3.8
+  tag: v3.3.9
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.1.5
+  tag: geos/v1.1.6
   develop: geos/develop
 
 GEOSchem_GridComp:


### PR DESCRIPTION
This updates ESMA_cmake to v3.3.8, fvdycore to v1.1.6, FVdycoreCubed_GridComp to v1.2.12

This adds the ability to use a new option `ESMA_USE_GFE_NAMESPACE` which defaults to `OFF`. 

If you set this to `ON`, you must then use the new GFE namespace style in CMake, e.g., `gftl` ==> `GFTL::gftl`. 

This is needed for testing and eventual move to Baselibs 6.2.0