### PR TITLE
Update to ESMA_env v3.2.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.0
+  tag: v3.2.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This is a zero-diff update to ESMA_env that just brings in some [extra code in `g5_modules`](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.2.1) that was available in the ADAS CVS tags. Seems useful and can't hurt!