### PR TITLE
Add externals for GEOS-Chem and HEMCO.

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -73,12 +73,14 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO
   remote: ../HEMCO.git
-  branch: GEOS/main
+  tag: geos/v2.2.0
+  develop: geos/develop 
 
-GEOS-chem:
+geos-chem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/@geos-chem
   remote: ../geos-chem.git
-  branch: feature/cakelle2/GCC_v13.0.0 
+  tag: geos/v13.0.0
+  develop: geos/develop
 
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART

--- a/components.yaml
+++ b/components.yaml
@@ -79,7 +79,7 @@ HEMCO:
 geos-chem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/@geos-chem
   remote: ../geos-chem.git
-  tag: geos/v13.0.0
+  tag: geos/v13.0.0-rc1
   develop: geos/develop
 
 GOCART:

--- a/components.yaml
+++ b/components.yaml
@@ -70,6 +70,16 @@ GEOSchem_GridComp:
   tag: v1.5.0
   develop: develop
 
+HEMCO:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO
+  remote: ../HEMCO.git
+  branch: GEOS/main
+
+GEOS-chem:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/@geos-chem
+  remote: ../geos-chem.git
+  branch: feature/cakelle2/GCC_v13.0.0 
+
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git


### PR DESCRIPTION
Add GEOS-Chem and HEMCO as external repositories. Once approved, I will submit a PR to [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp) to remove the legacy code copies of HEMCO and GEOS-Chem.