### PR TITLE
Update MAPL to v2.6.7

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.6
+  tag: v2.6.7
   develop: develop
 
 FMS:


### PR DESCRIPTION
This updates MAPL to v2.6.7. This is zero-diff to v2.6.6 but has some updates needed for the GEOSadas move to MAPL2 as well as being necessary for using `MAPL_GetResource` in Surface (see https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/428)