### PR TITLE
Updates for v10.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [10.19.1] - 2021-05-25
+
+### Zero-diff to previous release: NO
+### Restart Changes: NO
+### History Changes: NO
+
+Major changes include:
+
+1. Upgrade to MAPL v2.7.0 which changes how programs set up command line options.
+2. Update to FVdycoreCubed_GridComp v1.2.15 and GEOSgcm_App v1.5.1 for compatibility with MAPL v2.7.0.
+
 ## [10.19.0] - 2021-05-14
 
 ### Zero-diff to previous release: NO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 ## [10.19.1] - 2021-05-25
 
-### Zero-diff to previous release: NO
+### Zero-diff to previous release: YES
 ### Restart Changes: NO
-### History Changes: NO
+### History Changes: YES
 
 Major changes include:
 
 1. Upgrade to MAPL v2.7.0 which changes how programs set up command line options.
 2. Update to FVdycoreCubed_GridComp v1.2.15 and GEOSgcm_App v1.5.1 for compatibility with MAPL v2.7.0.
+3. Enable GEOSgcm to output the configuration values in `GEOS_SurfaceGridComp.rc`.
+4. Fixes a bug in the export of `SSKINW` (an internal state of Openwater) that was being filled incorrectly leading to `MAPL_UNDEF`. Now there are actual values.
+5. Merged changes present in GEOSadas-5_27_1_p3 that never made it into the GIT repo: revised stochastic perturbation tendency exports.
+6. A bug fix to prevent a seg-fault during the calculation of the GEOS-Chem lightning flash rate due to an array size mismatch.
+7. Add ability to write out energy components to file.
+8. Update gitignore for mepo updates.
+9. Follow MAPL's change to add a new `MAPL_CapOptions` constructor.
 
 ## [10.19.0] - 2021-05-14
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 10.19.0
+  VERSION 10.19.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/components.yaml
+++ b/components.yaml
@@ -29,14 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.1
+  tag: v1.4.2
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.6.8
+  tag: v2.7.0
   develop: develop
 
 FMS:
@@ -48,14 +48,14 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.12.1
+  tag: v1.12.2
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.14
+  tag: v1.2.15
   develop: develop
 
 fvdycore:
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.0
+  tag: v1.5.1
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
Update MAPL to v2.7.0. Requires updates to GEOSgcm_App and FVdycoreCubed_Gridcomp due to [interface change](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.7.0)

Also update other repos at the same time.