### PR TITLE
Update ESMA_cmake to v3.4.3

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.2
+  tag: v3.4.3
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This is a zero-diff update to ESMA_cmake v3.4.3. 

Per the release notes:
---
This is a zero-diff update to ESMA_cmake that adds two new features:

1. ESMA_cmake will now detect if `BASEDIR` is set in the environment and use that if not passed in via the command line. It will also make sure your Baselibs path has the `uname -s` arch in it since it is still required by some GEOS scripts.
2. Deprecate `CPP_DEBUG_<target>` in favor of `XFLAGS`. See below for more details.

---

## From `CHANGELOG`

### Changed

- Add ability to detect BASEDIR from the environment.
- Add checks to `FindBaselibs.cmake` to make sure BASEDIR has the right arch (as defined by `uname -s`) as this is still a requirement for GEOS run scripts. The code will also try to make a valid BASEDIR. That is, if you pass in `/path/to/baselibs`, but it sees `/path/to/baselibs/arch/lib` exists, it will allow that and try to use it.
- Previous option `CPP_DEBUG_<target` has now been replaced with a
  more fine-grained combination of cmake variables: `XFLAGS` and
  `XFLAGS_SOURCES`.   To use

  ```
  $cmake .. -DXFLAGS="foo bar=7 DEBUG" -DXFLAGS_SOURCES="<file1> <file2>"
  $ make
  ```

  NOTE: This change requires checking for specified sources in every
  directory (or rather in those that use `esma_set_this()` and thus
  add some overhead to cmake.  We may later decide to implement a
  per-target or per-directory pair of flags to address this, but that
  will be harder for the user to use.