### PR TITLE
Update to Baselibs 6.2.4. Enable GFE Namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gcc-build-env:
     docker:
-      - image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
+      - image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.1.0-openmpi_4.0.5-gcc_10.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.2.1
+  branch: feature/mathomp4/enable-gfe-namespace
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.4.2
+  branch: feature/mathomp4/enable-gfe-namespace
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR enables GFE namespace in CMake which is necessary to advance GEOS to newer Baselibs. This is a zero-diff update. The updates to Baselibs since v6.1.0 are:

### Updates

* Updates to GFE libraries. NOTE: Change to CMake linkage (see below)
  * gFTL v1.4.1
  * gFTL-shared v1.3.0
  * pFUnit v4.2.1
  * fArgParse v1.1.0
  * yaFyaml v0.5.1
  * pFlogger v1.5.0
  * GFE libraries are now
    *called* in a different way in projects that use GFE. For example,
    before you used:
    ```cmake
    target_link_libraries (library PUBLIC gftl gftl-shared)
    ```
    you will now use a CMake namespace:
    ```cmake
    target_link_libraries (library PUBLIC GFTL::gftl GFTL_SHARED::gftl-shared)
    ```
* ESMF 8_2_0_beta_snapshot_10
  * This beta is being used due to it fixing two bugs
    1. Fix for errors with alarms during replay
    2. Fix for regridding very-high resolution files
* cURL 7.77.0
* NCO 4.9.9
* HDF-EOS2 v3.0
* HDF-EOS5 v2.0