### PR TITLE
Update MAPL to v2.7.1

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.7.0
+  tag: v2.7.1
   develop: develop
 
 FMS:


### PR DESCRIPTION
This updates MAPL to v2.7.1. This is a zero-diff release that mainly has fixes for UFS work with GOCART/MAPL. You can see the [Release Notes here](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.7.1)