### PR TITLE
Update to NCEP_Shared v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.7.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.7.0)                                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.1.1](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.1.1)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.1](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.1)                          |
-| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v5.29.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v5.29.0)                             |
+| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                              |
 | [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.0.4](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.0.4)                                   |
 
 ## How to build GEOS GCM

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.7.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.7.0)                                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.1.1](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.1.1)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.1](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.1)                          |
-| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.1.1](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.1.1)                               |
+| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v5.29.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v5.29.0)                             |
 | [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.0.4](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.0.4)                                   |
 
 ## How to build GEOS GCM

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared
   remote: ../NCEP_Shared.git
-  tag: v5.29.0
+  tag: v1.2.0
   sparse: ./config/NCEP_Shared.sparse
   develop: main
 

--- a/components.yaml
+++ b/components.yaml
@@ -22,7 +22,7 @@ ecbuild:
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared
   remote: ../NCEP_Shared.git
-  tag: v1.1.1
+  tag: v5.29.0
   sparse: ./config/NCEP_Shared.sparse
   develop: main
 


### PR DESCRIPTION
This moves NCEP_Shared up the v5.29.0 tag to match with GEOSadas v5.29.0

All my tests show zero-diff as (I guess) everything GEOSgcm cares about in NCEP_Shared is okay.