### PR TITLE
Update CI to be more logical

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/GEOSgcm
             mepo clone
-            mepo develop GEOSgcm_App GEOSgcm_GridComp
             mepo status
       - run:
           name: "Mepo checkout-if-exists"

--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -15,7 +15,6 @@ phases:
       - echo CODEBUILD_RESOLVED_SOURCE_VERSION is ${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - git checkout $CODEBUILD_RESOLVED_SOURCE_VERSION
       - mepo clone
-      - mepo develop GEOSgcm_App GEOSgcm_GridComp
       #- mepo status
     finally:
       - echo "Mepo clone external repos" 

--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -13,9 +13,9 @@ phases:
       - git status
       - git branch
       - echo CODEBUILD_RESOLVED_SOURCE_VERSION is ${CODEBUILD_RESOLVED_SOURCE_VERSION}
-      - git checkout $CODEBUILD_RESOLVED_SOURCE_VERSION
+      - git checkout ${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - mepo clone
-      #- mepo status
+      - mepo status
     finally:
       - echo "Mepo clone external repos" 
   # This phase builds it

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -44,8 +44,6 @@ jobs:
         run: |
           mepo clone
           mepo status
-          mepo develop GEOSgcm_GridComp GEOSgcm_App
-          mepo status
       - name: Update other branches
         if:
           "!contains('refs/heads/main,refs/heads/develop', github.ref)"


### PR DESCRIPTION
It is not a good idea to do `mepo develop` in the fixture. Why, well, if something goes wrong in tagging, you might think all is okay but it's not because `develop` on one of the subrepos might work, but the fixed tag will not. Thus, you'd see the error in CI.