### PR TITLE
Minor update to GOCART components entry

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -85,8 +85,8 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  sparse: ./config/GOCART.sparse
   tag: v1.0.1
+  sparse: ./config/GOCART.sparse
   develop: develop
 
 mom:

--- a/components.yaml
+++ b/components.yaml
@@ -100,7 +100,7 @@ mom6:
   remote: ../MOM6.git
   tag: geos/v2.0.1
   develop: dev/gfdl
-  recurse_submodules: True
+  recurse_submodules: true
 
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App


### PR DESCRIPTION
Testing with mepo to fix a bug in `mepo save` showed that life is easier for the mepo developer (aka me) if the order of the YAML entries is consistent. So, since others components with sparse do:
```yaml
  local: ./src/Shared/@NCEP_Shared
  remote: ../NCEP_Shared.git
  tag: v1.1.1
  sparse: ./config/NCEP_Shared.sparse
  develop: main
```
where sparse is after tag and before develop, let's have GOCART do the same.