### PR TITLE
Changed path to mom and mom6 components 

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.6
+  tag: v1.4.7
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.16
+  tag: v1.2.17
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -90,13 +90,13 @@ GOCART:
   develop: develop
 
 mom:
-  local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOS_OceanGridComp/MOM_GEOS5PlugMod/@mom
   remote: ../MOM5.git
   tag: geos/5.1.0+1.1.1
   develop: geos5
 
 mom6:
-  local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM6_GEOSPlug/@mom6
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
   tag: geos/v2.0.1
   develop: dev/gfdl

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.12.4
+  tag: v1.12.5
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 


### PR DESCRIPTION
This PR is contingent on https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/448 and addresses https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/447. 