### PR TITLE
Add CMakePresets.json file

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,7 @@ on:
     # Do not run if the only files changed cannot affect the build
     paths-ignore:
       - "**.md"
+      - "**.json"
       - "ChangeLog-PreJason.txt"
       - "parallel_build.csh"
       - ".github/CODEOWNERS"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.mepo/
 parallel_build.o*
 log.*
+CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,126 @@
+﻿{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "BASEDIR": "$env{BASEDIR}",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}",
+        "CMAKE_BUILD_TYPE": "${presetName}"
+      }
+    },
+    {
+      "name": "base-gnu",
+      "hidden": true,
+      "inherits": "base-configure",
+      "displayName": "Base GNU Make Config",
+      "description": "Sets GNU Make generator",
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "base-ninja",
+      "hidden": true,
+      "inherits": "base-configure",
+      "displayName": "Base Ninja Config",
+      "description": "Sets Ninja generator",
+      "generator": "Ninja"
+    },
+    {
+      "name": "Release",
+      "inherits": "base-gnu",
+      "displayName": "Release Configure",
+      "description": "Release build using GNU Make generator"
+    },
+    {
+      "name": "Debug",
+      "inherits": "base-gnu",
+      "displayName": "Debug Configure",
+      "description": "Debug build using GNU Make generator"
+    },
+    {
+      "name": "Aggressive",
+      "inherits": "base-gnu",
+      "displayName": "Aggressive Configure",
+      "description": "Aggressive build using GNU Make generator"
+    },
+    {
+      "name": "Release-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Release Ninja Configure",
+      "description": "Release build using Ninja generator"
+    },
+    {
+      "name": "Debug-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Debug Ninja Configure",
+      "description": "Debug build using Ninja generator"
+    },
+    {
+      "name": "Aggressive-Ninja",
+      "inherits": "base-ninja",
+      "displayName": "Aggressive Ninja Configure",
+      "description": "Aggressive build using Ninja generator"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "base-build",
+      "hidden": true,
+      "displayName": "Base Build Config",
+      "description": "Sets default build options",
+      "jobs": 6,
+      "targets": ["install"]
+    },
+    {
+      "name": "Release",
+      "configurePreset": "Release",
+      "inherits": "base-build",
+      "displayName": "Release Build",
+      "description": "Release build using GNU Make generator"
+    },
+    {
+      "name": "Debug",
+      "configurePreset": "Debug",
+      "inherits": "base-build",
+      "displayName": "Debug Build",
+      "description": "Debug build using GNU Make generator"
+    },
+    {
+      "name": "Aggressive",
+      "configurePreset": "Aggressive",
+      "inherits": "base-build",
+      "displayName": "Aggressive Build",
+      "description": "Aggressive build using GNU Make generator"
+    },
+    {
+      "name": "Release-Ninja",
+      "configurePreset": "Release-Ninja",
+      "inherits": "base-build",
+      "displayName": "Release Ninja Build",
+      "description": "Release build using Ninja generator"
+    },
+    {
+      "name": "Debug-Ninja",
+      "configurePreset": "Debug-Ninja",
+      "inherits": "base-build",
+      "displayName": "Debug Ninja Build",
+      "description": "Debug build using Ninja generator"
+    },
+    {
+      "name": "Aggressive-Ninja",
+      "configurePreset": "Aggressive-Ninja",
+      "inherits": "base-build",
+      "displayName": "Aggressive Ninja Build",
+      "description": "Aggressive build using Ninja generator"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a `CMakePresets.json` file to GEOSgcm. This was similarly done in MAPL (see https://github.com/GEOS-ESM/MAPL/pull/924) and I'll recap the additions here. Note that for users this won't do much as unless they know how to use it, it's just a json file.

This is mainly for testing (by me and anyone else) who want to try out the functionality. It also adds `CMakeUserPresets.json` to the `.gitignore` per [CMake advice](https://cmake.org/cmake/help/v3.21/manual/cmake-presets.7.html#introduction).

For example, if you want to build GEOSgcm with Release, you can just do:
```console
cmake --preset Release
cmake --build --preset Release
```
and that'll do it. This is equivalent to:
```console
mkdir build-Release
cd build-Release
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install-Release
make -j6 install
```
By default, I've set it up so it uses `-j6` for the build. If you want more, you can do:
```
cmake --build --preset Release -j 8
```

Is this extraordinarily useful? I don't know, but I do know that CMake Presets are an active area of development in CMake, so this at least gives us a start at it!

NOTE: You need CMake 3.21 for this. 