### PR TITLE
Update to ESMA_env v3.3.1

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -5,7 +5,7 @@ phases:
   # This phase is weirdly named for a Fortran project
   install:
     commands:
-      - mpirun --version && gfortran --version && echo $BASEDIR && pwd && ls
+      - mpirun --version && ifort --version && echo $BASEDIR && pwd && ls
     finally:
       - echo "versions etc"
   pre_build:
@@ -14,8 +14,8 @@ phases:
       - git branch
       - echo CODEBUILD_RESOLVED_SOURCE_VERSION is ${CODEBUILD_RESOLVED_SOURCE_VERSION}
       - git checkout ${CODEBUILD_RESOLVED_SOURCE_VERSION}
+      - mepo init
       - mepo clone
-      - mepo status
     finally:
       - echo "Mepo clone external repos" 
   # This phase builds it
@@ -23,7 +23,7 @@ phases:
     commands: |
       mkdir build
       cd build
-      cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF
+      cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_BUILD_TYPE=Debug -DUSE_F2PY=OFF
       cd build
       make -j"$(nproc)" install
     finally:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.5.2](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.5.2)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.3.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.3.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.3.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.3.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.15](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.15)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.3.0
+  tag: v3.3.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This is a very minor update to ESMA_env that adds support for passing in `-rom` to `parallel_build.csh` at NAS.