### PR TITLE
Update CI and CMakeLists.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   gfortran-large:
     docker:
-      - image: gmao/ubuntu20-geos-env-bcs:v6.2.4-openmpi_4.0.5-gcc_10.3.0-bcs_v10.19.2
+      - image: gmao/ubuntu20-geos-env-bcs:v6.2.7-openmpi_4.0.6-gcc_11.2.0-bcs_v10.19.3
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -16,7 +16,7 @@ executors:
 
   gfortran-xlarge:
     docker:
-      - image: gmao/ubuntu20-geos-env-bcs:v6.2.4-openmpi_4.0.5-gcc_10.3.0-bcs_v10.19.2
+      - image: gmao/ubuntu20-geos-env-bcs:v6.2.7-openmpi_4.0.6-gcc_11.2.0-bcs_v10.19.3
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -29,7 +29,7 @@ executors:
 
   ifort-large:
     docker:
-      - image: gmao/ubuntu20-geos-env-bcs:v6.2.4-intelmpi_2021.2.0-intel_2021.2.0-bcs_v10.19.2
+      - image: gmao/ubuntu20-geos-env-bcs:v6.2.7-intelmpi_2021.2.0-intel_2021.2.0-bcs_v10.19.3
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN
@@ -38,7 +38,7 @@ executors:
 
   ifort-xlarge:
     docker:
-      - image: gmao/ubuntu20-geos-env-bcs:v6.2.4-intelmpi_2021.2.0-intel_2021.2.0-bcs_v10.19.2
+      - image: gmao/ubuntu20-geos-env-bcs:v6.2.7-intelmpi_2021.2.0-intel_2021.2.0-bcs_v10.19.3
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_AUTH_TOKEN

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.2.4-openmpi_4.0.5-gcc_10.3.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.2.7-openmpi_4.0.6-gcc_11.2.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
   set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    "Debug" "Release" "Aggressive")
 endif ()
 
 set (DOING_GEOS5 YES)


### PR DESCRIPTION
This CI updates the Docker images to use GCC 11.2 and Baselibs 6.2.7. The latter isn't really necessary but it had build fixes. 

I also set the "the possible values of build type for cmake-gui" in our CMakeLists.txt to the ones we actually do support. It only really affects `cmake-gui` and maybe `ccmake` so it should be pretty transparent to users as even I don't really know how to do that!