### PR TITLE
Add release tarball uploader

### DIFF
--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -1,0 +1,38 @@
+name: Create Complete Release Tarball
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+
+      - name: Checkout mepo
+        uses: actions/checkout@v2
+        with:
+          repository: GEOS-ESM/mepo
+          path: mepo
+
+      - name: Run mepo
+        run : |
+          cd ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+          ${GITHUB_WORKSPACE}/mepo/mepo clone
+
+      - name: Create tarball
+        run: |
+          tar --exclude-vcs --exclude=.mepo -cf ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+          xz -T6 ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar
+
+      - name: Upload tarball
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.COMPLETE.tar.xz -R ${{ github.repository_owner }}/${{ github.event.repository.name }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+


### PR DESCRIPTION
This PR adds a new GitHub Action that on release, creates and uploads a tarball to GitHub. So if @sdrabenh released v11.12.13, then in a minute or so, we *should* have a `GEOSgcm-v11.12.13.COMPLETE.tar.xz` file that is completely mepo'd and everything.