### PR TITLE
Update to ESMA_cmake 3.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.5.5](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.5.5)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.5.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.5.6)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.3.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.3.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.16](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.16)                  |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.5
+  tag: v3.5.6
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR brings in ESMA_cmake v3.5.6 which has updates needed to enable support for mepo style variants (see https://github.com/GEOS-ESM/GEOSgcm/issues/332 by @tclune ).

But this needs to be in place before anything else is merged in the various GEOS-ESM subrepos. This by itself works just fine and so can go in.