### PR TITLE
Updates needed for Cascade Lake at NCCS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ set (DOING_GEOS5 YES)
 
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
+
+# This flag at R4R8 means that FV3 is compiled at R4 but *linked* to 
+# FMS built at R8. This is needed as MOM6 is currently compiled as R8
+# and so the linker can only link to one FMS library.
 set (FV_PRECISION "R4R8" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/@cmake")

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  branch: feature/mathomp4/cascade-lake-nccs
+  tag: v3.3.2
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.2.15
+  branch: feature/mathomp4/cascade-lake-nccs
   develop: develop
 
 fvdycore:
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.2
+  branch: feature/mathomp4/cascade-lake-nccs
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.8.4
+  tag: v2.8.6
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.5
+  tag: v3.5.8
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.3.2
+  tag: v3.4.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.8
+  tag: v3.6.0
   develop: develop
 
 ecbuild:
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.4
+  branch: feature/mathomp4/cascade-lake-nccs
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: feature/mathomp4/cascade-lake-nccs
+  tag: v1.5.4
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This PR has three updates for Cascade Lake use at NCCS.

1. ESMA_env v3.4.0
   * Updates to Intel 2021.2
   * Move to Baselibs 6.2.7
   * Adds some support for TOSS3 at NAS
2. ESMA_cmake v3.6.0
   * Updates Intel Flags to be vectorized always (so far zero-diff)
3. GEOSgcm_App v1.5.4/v1.6.0 (to be made)
   * Adds support for Cascade Lake in run scripts 

Also, update to MAPL 2.8.6 because it's the latest with some bug fixes