### PR TITLE
Closes #342. Enable tarfile installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set (FV_PRECISION "R4R8" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")
 foreach (dir cmake @cmake cmake@)
   if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
     list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+    set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
 include (esma)
@@ -64,5 +65,14 @@ install(
    DESTINATION ${CMAKE_INSTALL_PREFIX}
    )
 
-# Adds abiilty to tar source
+# Adds ability to tar source
 include (esma_cpack)
+
+# This installs a tarball of the source code
+# in the installation directory.
+# MUST BE THE LAST CODE IN THIS FILE
+option(INSTALL_SOURCE_TARFILE "Create and install source tarfile" OFF)
+if(INSTALL_SOURCE_TARFILE)
+  install(CODE "set(CMAKE_PROJECT_NAME \"${CMAKE_PROJECT_NAME}\")")
+  install(SCRIPT "${ESMA_CMAKE_PATH}/esma_postinstall.cmake")
+endif()

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.5](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.5)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.1)                                  |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.1)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.6.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.6.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.4](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.4)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.5](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.5)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.2](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.2)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.0)                                  |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.4](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.4)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ This will install to a directory parallel to your `build` directory. If you pref
 ```
 and CMake will install there.
 
+###### Create and install source tarfile
+
+Note that running with `parallel_build.csh` will create and install a tarfile of the source code at build time. But if CMake is run by hand, this is not the default action (as many who build with CMake by hand are developers and not often running experiments). In order to enable this at install time, add:
+```
+-DINSTALL_SOURCE_TARFILE=ON
+```
+to your CMake command.
+
 ##### Build and Install with Make
 ```
 make -jN install

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.5.1
+  tag: v3.6.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.1
+  tag: v3.5.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.5
+  tag: v3.6.6
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,15 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  #tag: v3.4.0
-  branch: feature/mathomp4/postinstall
+  tag: v3.4.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  #tag: v3.6.2
-  branch: feature/mathomp4/postinstall
+  tag: v3.6.4
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,15 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0
+  #tag: v3.4.0
+  branch: feature/mathomp4/postinstall
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.2
+  #tag: v3.6.2
+  branch: feature/mathomp4/postinstall
   develop: develop
 
 ecbuild:
@@ -105,7 +107,8 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.5
+  #tag: v1.5.5
+  branch: feature/mathomp4/postinstall
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.5.0
+  tag: v3.5.1
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.4
+  tag: v3.6.5
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
Closes #342 

This is an omnibus PR for allowing installation of source tarfiles. Needs updates to:

- ESMA_env (https://github.com/GEOS-ESM/ESMA_env/pull/67) → ESMA_env v3.5.0
- ESMA_cmake (https://github.com/GEOS-ESM/ESMA_cmake/pull/225) → ESMA_cmake v3.6.6
- GEOSgcm_App (https://github.com/GEOS-ESM/GEOSgcm_App/pull/262)