### PR TITLE
Update to ESMA_cmake v3.6.6, ESMA_env 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.2](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.2)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.3](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.3)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.5](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.5)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.1)                                  |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.6](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.6)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.5.1)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.6.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.6.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.3](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.3)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.0)                                  |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.6.5](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.6.5)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.4.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.2.17](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.2.17)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.5.1
+  tag: v3.6.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.1
+  tag: v3.5.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.5
+  tag: v3.6.6
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.2
+  tag: v3.6.3
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0
+  tag: v3.4.1
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.6.3
+  tag: v3.6.5
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.5.0
+  tag: v3.5.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR update ESMA_cmake to fix a bug in BASEDIR handling.

ETA: Moved to use v3.6.6 in ESMA_cmake and v3.5.0 in ESMA_env. This echoes #343 but I've tested this and these changes are fine.