### PR TITLE
Update to GEOSgcm_GridComp v1.12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.6.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.6.0)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.5.6](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.5.6)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.12.7](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.12.7)                        |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.12.8](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.12.8)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.2.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.2.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.4.11](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.4.11)                             |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.12.7
+  tag: v1.12.8
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 


### PR DESCRIPTION
This PR moves GEOSgcm to use GEOSgcm_GridComp v1.12.8. This release has bugfixes for the `mk_*` (see https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/484)  program which affected `regrid.pl` as well as GEOSldas.