### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,11 @@
 
 # The GCM gatekeepers and CMake should know/approve these
 /.github/    @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
-/.circleci/    @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
-/.codebuild/    @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
+/.circleci/  @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
+/.codebuild/ @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
 
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team
+# The GEOS CMake Team should be notified about changes to the CMakeLists.txt files in this repository
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers
 
 # The GEOS CMake Team should be notified about and approve config changes
-/config/       @GEOS-ESM/cmake-team
+/config/ @GEOS-ESM/cmake-team @GEOS-ESM/gcm-gatekeepers


### PR DESCRIPTION
Realized that the @GEOS-ESM/gcm-gatekeepers were not co-owners of their own CMake files. Of course they should have to approve any CMake changes. Bad GitHub CODEOWNERS logic by Matt.