### PR TITLE
Updates for Rome nodes at NAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.0.6](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.0.6)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.8.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.8.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.8.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.8.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.10.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.10.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.4.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.4.1)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.5.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.5.7](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.5.6)                               |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.5.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.0)                               |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.14.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.0)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.0)                              |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.8.0
+  tag: v3.10.0
   develop: main
 
 cmake:
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.4.1
+  tag: v1.5.0
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.6.0
+  tag: v1.6.1
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This PR updates three sub-repos to make things work better at NAS on the Rome nodes. Now that models built on Rome can run on Intel cores (and vice versa), we can generalize the setup scripts and `parallel_build.csh`. 

The three updates are:

1. ESMA_env v3.10.0 (see: https://github.com/GEOS-ESM/ESMA_env/compare/v3.8.0...v3.10.0)
2. FVdycore_GridComp v1.5.0 (see: https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/compare/v1.4.1...v1.5.0)
3. GEOSgcm_App v1.6.1 (see: https://github.com/GEOS-ESM/GEOSgcm_App/compare/v1.6.0...v1.6.1)
