### PR TITLE
Updates for GEOSgcm v10.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,29 @@
 # Changelog
 
+## [10.21.0] - 2021-12-21
+
+### Zero-diff to Previous Release: NO
+### Restart Changes: YES (see below)
+
+Major Non-Zero-Diff Changes:
+1. Changed the default config to use new orbit parameters by @sdrabenh in [#277](https://github.com/GEOS-ESM/GEOSgcm_App/pull/277)
+2. Refactored RRTMG long-wave and short-wave radiation by @dr0cloud in [#492](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/492)
+3. Adding SHOC+EDMF updates by @narnold1 in [#479](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/479).
+   All restarts and variables within remain 0-diff except for the following:
+   1. moist_import
+      * added: EDMF_FRC, HL2, HL3, HLQT, QT2, QT3, W2, W3, WHL, WQT
+   2. moist_internal
+      * added: PDF_A
+   3. turb_import
+      * added: PHIS, SH, WTHV2
+   4. turb_internal
+      * added: QT2, QT3
+      * removed: BRUNTSHOC, CLD, DQDT_SHC, DQIDT_SHC, DQLDT_SHC, DTDT_SHC, LSHOC, SHEARSHOC, TKEBUOY, TKEDISS, TKESHEAR, TKETRANS, WTHV2
+      * changed: TKH "lev" coordinate to "edge" coordinate
+
 ## [10.20.0] - 2021-12-17
 
-### Zero-diff to previous release: NO
+### Zero-diff to Previous Release: NO
 ### Restart Changes: YES for TR
 
 Major Non-Zero-Diff Changes:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 10.20.0
+  VERSION 10.21.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.4.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.4.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.5.7](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.5.6)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.13.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.13.0)                        |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.0)                               |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.14.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.0)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.0)                              |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.13.0
+  tag: v1.14.0
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
@@ -105,7 +105,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.7
+  tag: v1.6.0
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
The updates are:

* GEOSgcm_GridComp [v10.14.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.0)
* GEOSgcm_App [v1.6.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.0)