### PR TITLE
CircleCI Cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run:
           name: "Compress artifacts"
           command: |
-            gzip /logfiles/*
+            gzip -9 /logfiles/*
       - store_artifacts:
           path: /logfiles
       # We need to persist the install for the next step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,15 +55,17 @@ workflows:
               compiler: [gfortran, ifort]
           context: 
             - docker-hub-creds
-      - run-gcm-exp:
-          name: run-gcm-exp-on-<< matrix.compiler >>
-          matrix:
-            parameters:
-              compiler: [gfortran, ifort]
-          context:
-            - docker-hub-creds
-          requires:
-            - build-GEOSgcm-on-<< matrix.compiler >>
+      ##################################################
+      # - run-gcm-exp:                                 #
+      #     name: run-gcm-exp-on-<< matrix.compiler >> #
+      #     matrix:                                    #
+      #       parameters:                              #
+      #         compiler: [gfortran, ifort]            #
+      #     context:                                   #
+      #       - docker-hub-creds                       #
+      #     requires:                                  #
+      #       - build-GEOSgcm-on-<< matrix.compiler >> #
+      ##################################################
 
 jobs:
   build-GEOSgcm:
@@ -108,14 +110,20 @@ jobs:
             cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSgcm
             make -j"$(nproc)" install |& tee /logfiles/make.log
             #MEDIUM# make -j4 install |& tee /logfiles/make.log
+      - run:
+          name: "Compress artifacts"
+          command: |
+            gzip /logfiles/*
       - store_artifacts:
           path: /logfiles
       # We need to persist the install for the next step
       # but only if we are running gcm tests
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - install-GEOSgcm
+      ###########################
+      # - persist_to_workspace: #
+      #     root: workspace     #
+      #     paths:              #
+      #       - install-GEOSgcm #
+      ###########################
 
   run-gcm-exp:
     parameters:


### PR DESCRIPTION
This PR does a few things for CircleCI. Soon, CircleCI will start charging for storage:
 
https://circleci.com/docs/2.0/persist-data/#how-to-calculate-an-approximation-of-your-monthly-costs

By *FAR* the most expensive storage we do is for the GCM run tests here. It was a noble experiment, but until I can do some cost calculations, etc., I'm going to turn off the GCM run tests and the `persist_to_workspace` bits here. 

I'm also going to try compressing the logfile artifacts as well.