### PR TITLE
Update to MAPL 2.15.1 and FV3 GC 1.6.0. Add editorconfig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          context: 
+          context:
             - docker-hub-creds
       ##################################################
       # - run-gcm-exp:                                 #
@@ -110,6 +110,13 @@ jobs:
             cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSgcm
             make -j"$(nproc)" install |& tee /logfiles/make.log
             #MEDIUM# make -j4 install |& tee /logfiles/make.log
+      - run:
+          name: "Retry build and install after failure"
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSgcm
+            make -j"$(nproc)" install |& tee /logfiles/make-retry.log
+            #MEDIUM# make -j4 install |& tee /logfiles/make-retry.log
+          when: on_fail
       - run:
           name: "Compress artifacts"
           command: |

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set (DOING_GEOS5 YES)
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
 
-# This flag at R4R8 means that FV3 is compiled at R4 but *linked* to 
+# This flag at R4R8 means that FV3 is compiled at R4 but *linked* to
 # FMS built at R8. This is needed as MOM6 is currently compiled as R8
 # and so the linker can only link to one FMS library.
 set (FV_PRECISION "R4R8" CACHE STRING "Precision of FV3 core (R4, R4R8, R8)")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.0)                              |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.1](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.1)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.15.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.15.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.15.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.15.1)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.8.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.8.0)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.10.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.10.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.5.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.1)                               |
@@ -26,7 +26,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.0)                              |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.1](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.1)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.14.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.14.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.15.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.15.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.15.0
+  tag: v2.15.1
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.14.1
+  tag: v2.15.0
   develop: develop
 
 FMS:
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.5.0
+  tag: v1.6.0
   develop: develop
 
 fvdycore:
@@ -74,7 +74,7 @@ HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO
   remote: ../HEMCO.git
   tag: geos/v2.2.1
-  develop: geos/develop 
+  develop: geos/develop
 
 geos-chem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/@geos-chem


### PR DESCRIPTION
This PR updates GEOS to use MAPL 2.15.0 and FV3 GC 1.6.0. In truth, there really isn't much here for the GCM. These releases were mainly for the GEOSctm which builds with `FV_PRECISION=R8` and @bena-nasa fixed some things to allow that. This should be zero-diff.

ETA: This PR now moves to MAPL 2.15.1. This version of MAPL is "sort of" non-zero-diff for History output. The actual fields/variables are zero-diff, but there have been changes to metadata as well as `lat` and `lon` are now 64-bit/double. So, if you use `cdo diffn` History output is identical. But if you use `nccmp` with the right options, it will see all sorts of changes and fail.

Also, add a `.editorconfig` file because I like it and it makes the files consistent (when used with an EditorConfig-aware editor).