### PR TITLE
Closes #371. Add RRTMGP as a fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,15 +108,7 @@ jobs:
           name: "Build and install"
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSgcm
-            make -j"$(nproc)" install |& tee /logfiles/make.log
-            #MEDIUM# make -j4 install |& tee /logfiles/make.log
-      - run:
-          name: "Retry build and install after failure"
-          command: |
-            cd ${CIRCLE_WORKING_DIRECTORY}/workspace/build-GEOSgcm
-            make -j"$(nproc)" install |& tee /logfiles/make-retry.log
-            #MEDIUM# make -j4 install |& tee /logfiles/make-retry.log
-          when: on_fail
+            make -j"$(nproc)" install |& tee /logfiles/make.log || make -j4 install |& tee /logfiles/make-retry.log
       - run:
           name: "Compress artifacts"
           command: |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.15.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.15.1)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
+| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [v1.5](https://github.com/GEOS-ESM/rte-rrtgmp/releases/tag/v1.5)                           |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |
 | [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.0.4](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.0.4)                                   |
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.17.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.17.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
-| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [v1.5](https://github.com/GEOS-ESM/rte-rrtgmp/releases/tag/v1.5)                           |
+| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |
 | [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.0.4](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.0.4)                                   |
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.1)                               |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.14.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.0)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
-| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.0)                              |
+| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.1](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.1)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.17.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.17.0)                                    |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.7.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.7.0)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.6.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.6.1)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.14.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.0)                        |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.14.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.14.1)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v1.0.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v1.0.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -102,6 +102,13 @@ mom6:
   develop: dev/gfdl
   recurse_submodules: true
 
+RRTMGP:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOS_RadiationShared/@RRTMGP
+  remote: ../rte-rrtmgp.git
+  tag: v1.5
+  develop: develop
+  sparse: ./config/RRTMGP.sparse
+
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git

--- a/components.yaml
+++ b/components.yaml
@@ -106,7 +106,7 @@ RRTMGP:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOS_RadiationShared/@RRTMGP
   remote: ../rte-rrtmgp.git
   tag: v1.5
-  develop: develop
+  develop: geos/develop
   sparse: ./config/RRTMGP.sparse
 
 GEOSgcm_App:

--- a/components.yaml
+++ b/components.yaml
@@ -112,7 +112,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.6.1
+  branch: feature/pnorris/#522-incorporate-RRTMGP-v1.5
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -105,7 +105,7 @@ mom6:
 RRTMGP:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSradiation_GridComp/GEOS_RadiationShared/@RRTMGP
   remote: ../rte-rrtmgp.git
-  tag: v1.5
+  tag: geos/v1.5+1.0.0
   develop: geos/develop
   sparse: ./config/RRTMGP.sparse
 

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.5.0
+  tag: v1.5.1
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 
@@ -112,7 +112,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: feature/pnorris/#522-incorporate-RRTMGP-v1.5
+  tag: v1.6.2
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  branch: feature/mathomp4/add-rrtmgp-fork
+  tag: v1.14.1
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 

--- a/components.yaml
+++ b/components.yaml
@@ -48,7 +48,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.14.0
+  branch: feature/mathomp4/add-rrtmgp-fork
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 

--- a/config/RRTMGP.sparse
+++ b/config/RRTMGP.sparse
@@ -1,0 +1,2 @@
+/*
+!/rrtmgp/data


### PR DESCRIPTION
Closes #371 

This PR will move GEOS to use RRTMGP as a fork. 

Contingent on: https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/528