### PR TITLE
Update ESMA_cmake and ecbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 | Repository                                                                     | Version                                                                                             |
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
-| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.1.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.8.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.8.0)                                |
+| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.10.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.10.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.11.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.11.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,13 +11,13 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.8.0
+  tag: v3.10.0
   develop: develop
 
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v1.1.0
+  tag: geos/v1.2.0
 
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared


### PR DESCRIPTION
This PR brings in updates to ESMA_cmake and ecbuild (GEOS fork). The first adds a `FindESMF.cmake` and the second updates the `FindNetCDF.cmake` in our ecbuild.

These files are from NOAA-EMC and allow MAPL to build with Spack and GNU. 

It doesn't affect Baselibs builds of GEOS and is zero-diff in my testing.