### PR TITLE
Update Chem to 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.8.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.8.0)                         |
+| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.8.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.8.1)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.7.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.7.0)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.15.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.15.0)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.8.0
+  tag: v1.8.1
   develop: develop
 
 HEMCO:


### PR DESCRIPTION
This PR update GEOSchem_GridComp to v1.8.1. This has a bugfix for Achem (see https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/164) for running GEOSgcm with GOCART2G on GNU compilers.