### PR TITLE
Update to MAPL 2.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.4](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.4)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.2](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.2)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.17.2](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.17.2)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.18.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.18.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.17.2
+  tag: v2.18.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates MAPL to [v2.18.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.18.0). This has the changes from @atrayano that makes the GOCART2G History output in the way @amdasilva wanted.

@sdrabenh Please do your own tests with this. Make sure it's all good for you too. I think it is, but good to have more testing.

Note it should be zero-diff, but some history fields will be renamed.