### PR TITLE
GitHub Actions for MAPLv3 development

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
@@ -1,0 +1,10 @@
+## :memo:  Automatic PR: `main` → `release/MAPL-v3`
+
+### Description
+
+<!-- Write your description here -->
+
+## :file_folder:  Modified files
+<!-- Diff files - START -->
+<!-- Diff files - END -->
+

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -1,0 +1,30 @@
+name: Push to Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run the action
+        uses: devops-infra/action-pull-request@v0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source_branch: main
+          target_branch: release/MAPL-v3
+          label: automatic,MAPL3,Skip Changelog
+          template: .github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+          get_diff: true
+          assignee: ${{ github.actor }}
+          old_string: "<!-- Write your description here -->"
+          new_string: ${{ github.event.commits[0].message }}
+          title: Auto PR - main → MAPL-v3 - ${{ github.event.commits[0].message }}
+


### PR DESCRIPTION
MAPL will soon be working toward a version 3 that will have incompatibilities to MAPL 2. This branch is now on this repository called `release/MAPL-v3` and will allow the SI Team to make changes to this repository while not affecting `main` directly.

What this PR does is add a GitHub Action so that any push to `main` (aka, any PR merged into `main`) also automatically makes a PR from `main` into `release/MAPL-v3`.

This way, our tracking branch can "keep up" with `main` and once MAPL 3 is ready to go, all that is needed is to merge `release/MAPL-v3` into `main` and we are good.