### PR TITLE
Update ESMA_cmake and ESMA_env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  circleci-tools: geos-esm/circleci-tools@0.11.0
+  circleci-tools: geos-esm/circleci-tools@0.12.0
 
 workflows:
   build-test:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.2.8-openmpi_4.0.6-gcc_11.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.2.13-openmpi_4.1.2-gcc_11.2.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.10.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.10.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.11.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.11.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.11.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.12.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.12.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.11.0
+  tag: v3.12.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.10.0
+  tag: v3.11.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates ESMA_cmake to v3.11.0 and ESMA_env to v3.12.0. The changes are:

- ESMA_cmake
  - Updates for Spack builds
- ESMA_env
  - Moves GEOS to use Baselibs 6.2.13 (needed for MAPL development)
  - `g5_modules` now loads a combo Python2 Python3 GEOSpyD modulefile as a precursor to moving to Python 3 entirely
- CI
  - Moves CI to use that Baselibs as well

All my tests show this is zero-diff for GEOS.