### PR TITLE
Fixes #387. Updates for Spack Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.2](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.2)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.5](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.5)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.19.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.18.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.19.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.19.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)          |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.7.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.7.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.15.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.15.0)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
-| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.1)                               |
+| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.2](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.2)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.5](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.5)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.18.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.18.0)                                    |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.11.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.12.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.12.0)                                |
-| [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.7](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.7) |
+| [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.9.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.9.0)                         |
@@ -25,13 +25,13 @@
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.5](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.5)                                    |
-| [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.2](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.2)                         |
+| [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.18.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.18.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.2](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.2)                          |
-| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)
+| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |
-| [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.0.4](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.0.4)                                   |
+| [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.1.0](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.1.0)                                   |
 
 ## How to build GEOS GCM
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | ----------                                                                     | -------                                                                                             |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.11.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.12.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.12.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.13.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ MAPL:
 FMS:
   local: ./src/Shared/@FMS
   remote: ../FMS.git
-  tag: geos/2019.01.02+noaff.7
+  tag: geos/2019.01.02+noaff.8
   develop: geos/release/2019.01
 
 GEOSgcm_GridComp:
@@ -73,7 +73,7 @@ GEOSchem_GridComp:
 HEMCO:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/Shared/HEMCO/@HEMCO
   remote: ../HEMCO.git
-  tag: geos/v2.2.2
+  tag: geos/v2.2.3
   develop: geos/develop
 
 geos-chem:
@@ -117,7 +117,7 @@ GEOSgcm_App:
 UMD_Etc:
   local: ./src/Applications/@UMD_Etc
   remote: ../UMD_Etc.git
-  tag: v1.0.4
+  tag: v1.1.0
   develop: main
 
 CPLFCST_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.5.1
+  tag: v1.5.2
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 


### PR DESCRIPTION
Closes #387 

This PR gathers up the upstream CMake changes for Spack support. It will stay draft until everything is released as a tag.