### PR TITLE
Change develop branch of MOM6 to main

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -104,7 +104,7 @@ mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
   tag: geos/v2.0.2
-  develop: dev/gfdl
+  develop: main
   recurse_submodules: true
 
 cice6:


### PR DESCRIPTION
This is a change to how the MOM6 repo is handled by mepo. Namely, the parent repo of our fork is now [mom-ocean/MOM6](https://github.com/mom-ocean/MOM6), but used to be a different repo which had a `dev/gfdl` branch. At that time, we said "Okay, let `dev/gfdl` be our development branch as well."

However, @sanAkel, in conversation with @marshallward, says that mom-ocean is the right one to fork from and since it does not have a `dev/gfdl` branch, our fork shouldn't either. In lieu of a `geos/main` or our own development branch, we might as well point our repo to `main`.

Note that @sanAkel mainly does work with the MOM6 folks directly (and any changes feed through them), so we probably won't need GEOS-specific branches on our fork unless things really diverge.