### PR TITLE
Update FV3 GC to 1.8.0, fvdycore to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.12.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.13.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.6.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.8.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.9.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.9.1)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.7.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.7.2)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.15.2](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.15.2)                        |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.1.0)                        |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.3.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.4.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.4.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.3](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.3)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.5](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.5)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |

--- a/components.yaml
+++ b/components.yaml
@@ -55,13 +55,13 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.6.0
+  tag: v1.8.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.3.0
+  tag: geos/v1.4.0
   develop: geos/develop
 
 GEOSchem_GridComp:


### PR DESCRIPTION
This PR updates GEOSgcm to use:

* FVdycoreCubed_GridComp [v1.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.8.0)
* fvdycore [geos/v1.4.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.4.0)

This updates are primarily for Spack compatibility (see #387). The Fvdycore_Cubed update also includes a change from @sdeastham that suppresses a print when using AdvCore.

These are zero-diff.