### PR TITLE
Update to MAPL 2.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.4](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.3)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.7](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.7)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.20.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.20.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.21.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.21.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.3](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.3)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.20.0
+  tag: v2.21.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOSgcm to use [MAPL 2.21.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.21.0). 

The main impetus for this PR is to quash ESMF errors found during the nightly test runs. MAPL 2.21 has a fix for History handling that makes ESMF happier. It is zero-diff in all testing as, really, nothing of vital import in MAPL itself changed, just bug fixes and some updates from @bena-nasa for PRINTSPEC use.