### PR TITLE
Update to ESMA_cmake v3.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.0.1)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.12.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.15.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.15.1)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.13.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.8.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.12.0
+  tag: v3.15.1
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates GEOSgcm to use ESMA_cmake v3.15.1. This update mainly has updates to how finding ESMF is handed in our CMake system.

Note that this is technically required for https://github.com/GEOS-ESM/GMAO_Shared/pull/262 though you need to build the full ADAS to find that out.