### PR TITLE
Update to MAPL 2.21.3, ESMA_cmake 3.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.4](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.3)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.7](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.7)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.21.2](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.21.2)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.21.3](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.21.3)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.3](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.3)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.21.2
+  tag: v2.21.3
   develop: develop
 
 FMS:


### PR DESCRIPTION
This updates GEOSgcm to MAPL 2.21.3. The differences to 2.21.0 are pretty minor. The main update is that this has a fix for the SCM when run in Debug mode.

ETA: I also added an update to ESMA_cmake. This is just as trivial as 3.16.0 is mainly focused on NAG Fortran...which can't even build GEOSgcm!
