### PR TITLE
Update to ESMA_env 3.14.0 and ESMA_cmake v3.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+# Anchor to prevent forgetting to update a version
+baselibs_version: &baselibs_version v6.3.1
+
 orbs:
   ci: geos-esm/circleci-tools@1
 
@@ -12,9 +15,8 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler:
-                - gfortran
-                - ifort
+              compiler: [ifort, gfortran]
+          baselibs_version: *baselibs_version
           repo: GEOSgcm
           persist_workspace: false # Needs to be true to run fv3/gcm experiment, costs extra
       ##################################################
@@ -25,6 +27,7 @@ workflows:
       #     matrix:                                    #
       #       parameters:                              #
       #         compiler: [gfortran, ifort]            #
+      #     baselibs_version: *baselibs_version        #
       #     requires:                                  #
       #       - build-GEOSgcm-on-<< matrix.compiler >> #
       #     repo: GEOSgcm                              #

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env-mkl:v6.2.13-openmpi_4.1.2-gcc_11.2.0
+      image: gmao/ubuntu20-geos-env-mkl:v6.3.1-openmpi_4.1.2-gcc_11.2.0
       credentials:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.0.1)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.16.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.16.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.13.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.17.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.17.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v3.14.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v3.14.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.8.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.13.0
+  tag: v3.14.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.16.0
+  tag: v3.17.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates GEOS to use:

1. ESMA_env v3.14.0
  - Moves to use Baselibs 6.3.1
2. ESMA_cmake v3.17.0
  - Updates for Apple Silicon support
  - Change to GNU Release flags

NOTE That for GNU Release runs of GEOS, this will be **non-zero-diff**. The change was to better support GCC 12. But this is **zero-diff** for Intel Fortran.