### PR TITLE
Update to MAPL 2.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.5](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.5)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.7](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.7)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.21.3](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.21.3)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.22.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.22.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.3](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.3)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.21.3
+  tag: v2.22.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOSgcm to MAPL 2.22.0. This is a zero-diff update and brings in a few fixes and updates:

- Fix in pfio when missing values are NaN
- Fix in History when trying to write to a file that already exists
- CMake updates for better building with Spack
- Added monotonic regridding option
- Various CI improvements
