### PR TITLE
Add @QuickChem under @GEOSchem_GridComp

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.9.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.9.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.9.5](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.9.5)                         |
+| [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.7.5](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.7.5)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.16.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.16.0)                        |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.0.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.0.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -88,6 +88,12 @@ GOCART:
   tag: v2.0.7
   develop: develop
 
+QuickChem:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@QuickChem
+  remote: ../QuickChem.git
+  tag: v1.0.0
+  develop: main
+
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git


### PR DESCRIPTION
A new QuickChem module is introduced, aimed at providing lightweight implementations of key chemical species. The project is led by B. Duncan, coordinating with A. da Silva and L. Ott. The initial species, provided in v1.0.0, is OH, based on an ML algorithm of D. Anderson .

QuickChem will be supported in an upcoming release of GEOSchem_GridComp. It will not be run by default.

This PR is zero diff.