### PR TITLE
Update components.yaml for ocean model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.7.5](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.7.5)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.16.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.16.0)                        |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.0.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.0.0)                    |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.1.0)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.1.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.1.1)                        |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.4.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.4.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.5.7](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.5.7)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.0.7](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.0.7)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.23.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.23.1)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.3](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.3)                          |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.4](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.4)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.5+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.5%2B1.0.0)          |
 | [SIS2](https://github.com/GEOS-ESM/SIS2)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/SIS2/releases/tag/geos%2Fv0.0.1)                          |

--- a/components.yaml
+++ b/components.yaml
@@ -97,7 +97,7 @@ QuickChem:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v1.1.0
+  tag: v1.1.1
   develop: develop
 
 mom:
@@ -109,7 +109,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v2.0.3
+  tag: geos/v2.0.4
   develop: main
   recurse_submodules: true
 


### PR DESCRIPTION
This PR updates:
- [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp) to `v1.1.1`
- [GEOS MOM6 _fork_](https://github.com/GEOS-ESM/MOM6/) to  `geos/v2.0.4`