### PR TITLE
Update to MAPL 2.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.1.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.1.0)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.25.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.25.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.26.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.26.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.0.4](https://github.com/GEOS-ESM/MOM6/releases/tag/geos%2Fv2.0.4)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.0)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.25.0
+  tag: v2.26.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates MAPL to v2.26.0. This version contains a bugfix needed for testing with ExtData2G.

cc: @sdrabenh 