### PR TITLE
Updates for Spack Stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # Anchors to prevent forgetting to update a version
 baselibs_version: &baselibs_version v7.5.0
-bcs_version: &bcs_version v10.22.3
+bcs_version: &bcs_version v10.23.0
 
 orbs:
   ci: geos-esm/circleci-tools@1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,46 @@ foreach (dir cmake @cmake cmake@)
 endforeach ()
 include (esma)
 
+# Add CMake for when not using Baselibs
+if (NOT Baselibs_FOUND)
+  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+  find_package(MPI)
+
+  find_package(NetCDF REQUIRED C Fortran)
+  add_definitions(-DHAS_NETCDF4)
+  add_definitions(-DHAS_NETCDF3)
+  add_definitions(-DNETCDF_NEED_NF_MPIIO)
+  add_definitions(-DHAS_NETCDF3)
+
+  find_package(HDF5 REQUIRED)
+  if(HDF5_IS_PARALLEL)
+     add_definitions(-DH5_HAVE_PARALLEL)
+  endif()
+
+  if (NOT TARGET esmf)
+    find_package(ESMF MODULE REQUIRED)
+
+    # ESMF as used in MAPL requires MPI
+    # NOTE: This looks odd because some versions of FindESMF.cmake out in the
+    #       world provide an "esmf" target while others provide "ESMF". So we
+    #       need this ugliness to support both.
+    if (TARGET esmf)
+      target_link_libraries(esmf INTERFACE MPI::MPI_Fortran)
+    else()
+      target_link_libraries(ESMF INTERFACE MPI::MPI_Fortran)
+      # MAPL and GEOS use lowercase target due to historical reasons but
+      # the latest FindESMF.cmake file from ESMF produces an ESMF target.
+      add_library(esmf ALIAS ESMF)
+    endif()
+  endif ()
+
+  find_package(GFTL_SHARED REQUIRED)
+
+  find_package(ZLIB REQUIRED)
+  # Another issue with historical reasons, old/wrong zlib target used in GEOS
+  add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
+endif ()
+
 ecbuild_declare_project()
 
 # Generic DFLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,16 @@ if (NOT Baselibs_FOUND)
   endif()
 
   if (NOT TARGET esmf)
+    if (DEFINED ENV{esmf_ROOT})
+      message (STATUS "Found esmf_ROOT in environment: $ENV{esmf_ROOT}")
+      find_path(ESMF_CMAKE_PATH FindESMF.cmake HINTS "$ENV{esmf_ROOT}/cmake")
+      message (STATUS "Found FindESMF.cmake in: ${ESMF_CMAKE_PATH}")
+      if (ESMF_CMAKE_PATH)
+        message (STATUS "Appending to CMAKE_PREFIX_PATH: ${ESMF_CMAKE_PATH}")
+        list (APPEND CMAKE_MODULE_PATH ${ESMF_CMAKE_PATH})
+      endif ()
+    endif ()
+
     find_package(ESMF MODULE REQUIRED)
 
     # ESMF as used in MAPL requires MPI
@@ -78,6 +88,18 @@ if (NOT Baselibs_FOUND)
   find_package(ZLIB REQUIRED)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
+
+  # Using FMS from spack requires updates to fvdycore due to interface changes
+  # in FMS 2022. This is commented for now until this transition can occur.
+  #################################################
+  # find_package(FMS QUIET COMPONENTS R4 R8)      #
+  # if (FMS_FOUND)                                #
+  #   # We need aliases due to historical reasons #
+  #   add_library(fms_r4 ALIAS FMS::fms_r4)       #
+  #   add_library(fms_r8 ALIAS FMS::fms_r8)       #
+  # endif ()                                      #
+  #################################################
+
 endif ()
 
 ecbuild_declare_project()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.18.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.18.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.4.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.4.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.11.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.11.0)                  |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.12.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.0)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.10.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.10.1)                       |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
@@ -26,7 +26,7 @@
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.17.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.17.0)                        |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.0.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.0.0)                    |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.1.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.1.1)                        |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.4.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.4.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.5.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.5.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.1.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.1.0)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |

--- a/components.yaml
+++ b/components.yaml
@@ -55,13 +55,13 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.11.0
+  tag: v1.12.0
   develop: develop
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v1.4.0
+  tag: geos/v1.5.0
   develop: geos/develop
 
 GEOSchem_GridComp:

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -4,7 +4,12 @@ esma_add_subdirectories (
   NCEP_Shared
   )
 
-# Special case - FMS is built twice with two
-# different precisions.
-esma_add_subdirectory (FMS RENAME fms_r4)
-esma_add_subdirectory (FMS RENAME fms_r8)
+if (NOT FMS_FOUND)
+  message (STATUS "FMS library not found. Building FMS from source.")
+  # Special case - FMS is built twice with two
+  # different precisions.
+  esma_add_subdirectory (FMS RENAME fms_r4)
+  esma_add_subdirectory (FMS RENAME fms_r8)
+else ()
+  message (STATUS "FMS library found. Using FMS from ${FMS_DIR}")
+endif ()


### PR DESCRIPTION
This PR is needed for building GEOSgcm with spack-stack (see https://github.com/NOAA-EMC/spack/pull/174).

Here we update the main `CMakeLists.txt` for the case where Baselibs is not found so that all the needed `find_package()` and `add_library(ALIAS)` calls can be made. Testing shows that this is zero-diff.

I've also added a test for the `esmf_ROOT` environment variable that Spack creates and use that to find the `FindESMF.cmake` file. Not perfect, but now when building by hand you don't have to do `-DCMAKE_MODULE_PATH=${esmf_ROOT}/cmake`.

Also, this adds a smidge of the changes needed for FMS-in-spack. I can't turn this on by default due to changes that are needed in fvdycore (see https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/pull/51). As this is an *interface* change, we have to go whole-hog into it.

Related PRs that are *NOT* necessary, just future proofing for FMS-in-Baselibs/FMS-in-spack:

- [x] https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/180 → Released as [v1.12.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.0)
- [x] https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/pull/54 → Released as [geos/v1.5.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.5.0)
- [ ] https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/643 → Currently in `develop`

(And there is also https://github.com/GEOS-ESM/ESMA_env/pull/82 but this is going to be a ways away...)