### PR TITLE
Build Docker containers on Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,24 @@
 version: 2.1
 
+parameters:
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
 # Anchors to prevent forgetting to update a version
+os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.5.0
 bcs_version: &bcs_version v10.23.0
+tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:
   ci: geos-esm/circleci-tools@1
@@ -32,3 +48,45 @@ workflows:
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
+  build-and-publish-docker:
+    when:
+      equal: [ "release", << pipeline.parameters.GHA_Event >> ]
+    jobs:
+      - ci/publish-docker:
+          filters:
+            tags:
+              only: /^v.*$/
+          name: publish-intel-docker-image
+          context:
+            - docker-hub-creds
+            - ghcr-creds
+          os_version: *os_version
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+          container_name: geosgcm
+          mpi_name: intelmpi
+          mpi_version: 2021.6.0
+          compiler_name: intel
+          compiler_version: 2022.1.0
+          image_name: geos-env-bcs
+          tag_build_arg_name: *tag_build_arg_name
+          resource_class: xlarge
+      - ci/publish-docker:
+          filters:
+            tags:
+              only: /^v.*$/
+          name: publish-gcc-docker-image
+          context:
+            - docker-hub-creds
+            - ghcr-creds
+          os_version: *os_version
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+          container_name: geosgcm
+          mpi_name: openmpi
+          mpi_version: 4.1.4
+          compiler_name: gcc
+          compiler_version: 12.1.0
+          image_name: geos-env-bcs
+          tag_build_arg_name: *tag_build_arg_name
+          resource_class: xlarge

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,25 @@
+# GEOSgcm Dockerfile
+
+ARG osversion
+ARG imagename
+ARG baselibversion
+ARG bcsversion
+ARG mpiname
+ARG mpiversion
+ARG compilername
+ARG compilerversion
+
+ARG BASE_IMAGE=gmao/${osversion}-${imagename}:${baselibversion}-${mpiname}_${mpiversion}-${compilername}_${compilerversion}-bcs_${bcsversion}
+FROM ${BASE_IMAGE}
+
+ARG gcmversion
+
+RUN git clone -b ${gcmversion} https://github.com/GEOS-ESM/GEOSgcm.git /GEOSgcm-src && \
+    cd /GEOSgcm-src && \
+    mepo clone && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/GEOSgcm/install -DBASEDIR=$BASEDIR/Linux -DUSE_F2PY=OFF -DCMAKE_Fortran_COMPILER=$FC -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX && \
+    make -j $(nproc) install/strip && \
+    cd / && \
+    rm -rf /GEOSgcm-src

--- a/.github/workflows/trigger-circleci-pipeline-on-release.yml
+++ b/.github/workflows/trigger-circleci-pipeline-on-release.yml
@@ -1,0 +1,12 @@
+on:
+  release:
+    types: [published]
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CircleCI Trigger on Release
+        id: docker-build
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.10.4](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.10.4)                       |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.8.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.8.0)                               |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.8.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.8.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.17.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.17.0)                        |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.1.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.1.0)                    |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.1.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.1.1)                        |

--- a/components.yaml
+++ b/components.yaml
@@ -142,7 +142,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: feature/mathomp4/updates-for-singularity-gcmapp
+  tag: v1.8.1
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -55,7 +55,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v1.10.0
+  tag: v1.11.0
   develop: develop
 
 fvdycore:
@@ -142,7 +142,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.7.5
+  branch: feature/mathomp4/updates-for-singularity-gcmapp
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This PR adds GitHub Actions and CircleCI code to build a Docker image on release. This was based on tests in the gcm-container-test repo which was a fork of this.

---

Testing on discover (which still requires a bit of hand work), shows that the container isn't that much different from a native build. The columns are model throughput at days/day and are the average of 3 runs.

Resolution  |  Native    |  Container  |  Speedup
------------|------------|-------------|---------
C24         |  1120.953  |  1034.057   |  0.92
C48         |  526.617   |  508.689    |  0.97
C90         |  230.720   |  236.095    |  1.02
C180        |  141.796   |  141.228    |  1.00
C360        |  132.044   |  127.004    |  0.96
C720        |  55.737    |  52.132     |  0.94
