### PR TITLE
Update ESMA_env to v4.5.0 and ESMA_cmake to v3.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.0.1)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.18.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.18.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.19.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.19.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.5.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.12.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.1)                  |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.18.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.18.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.4.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.4.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.5.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.12.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.1)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.4.0
+  tag: v4.5.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.18.0
+  tag: v3.19.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR is needed to fully support the multiple GMI mechanism Chem PR from @ssteenro [now in GEOSchem_GridComp v1.10.3](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.10.3) (which I'm guessing @mmanyin will be making a PR for or will inform @sdrabenh to add to next release 😄 ).

The ESMA_env change adds a `-gmi_mechanism` option to `parallel_build.csh` (via `build.csh`) so users can easily change mechanisms.

I've also pushed a change to move to ESMA_cmake v3.19.0. This mainly changes the GNU debug flags as well as has a check on if `CMAKE_INSTALL_PREFIX` is writable (so you don't have to wait until the end of the build to find out, it dies quick).
