### PR TITLE
Update to ESMA_env v4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.2.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.2.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.19.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.19.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.5.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.6.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.6.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.12.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.1)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ To obtain a debug version, you can run `parallel_build.csh -debug` which will bu
 Note that running with `parallel_build.csh` will create and install a tarfile of the source code at build time. If you wish to avoid
 this, run `parallel_build.csh` with the `-no-tar` option.
 
+#### Passing additional CMake options to `parallel_build.csh`
+
+While `parallel_build.csh` has many options, it does not cover all possible CMake options possible in GEOSgcm. If you wish to
+pass additional CMake options to `parallel_build.csh`, you can do so by using `--` and then the CMake options. Note that *anything*
+after the `--` will be interpreted as a CMake option, which could lead to build issues if not careful.
+
+For example, if you want to build a develop Debug build on Cascade Lake while turning on StratChem reduced mechanism and the CODATA
+2018 options:
+
+```
+parallel_build.csh -develop -debug -cas -- -DSTRATCHEM_REDUCED_MECHANISM=ON -DUSE_CODATA_2018_CONSTANTS=ON
+```
+
+As noted above all the "regular" `parallel_build.csh` options must be listed before the `--` flag.
+
 ---
 
 ### Multiple Steps for Building the Model

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.5.0
+  tag: v4.6.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates GEOSgcm to use ESMA_env v4.6.0. This update has a new feature for `parallel_build.csh` to allow for arbitrary CMake options to be passed in. 

This is done by the use of `-- ` to trigger `parallel_build.csh` to say "everything after this is an extra CMake option". Per the updated usage:

```
extra cmake options

   To pass in additional CMake options not covered by the above flags,
   after all your flags, add -- and then the options. For example:

     parallel_build.csh -debug -- -DSTRATCHEM_REDUCED_MECHANISM=ON -DUSE_CODATA_2018_CONSTANTS=ON

   and these options will be appended to the CMake command.

   NOTE: Once you use --, you cannot use any more flags. All options
   after -- will be passed to CMake and if not a valid CMake option,
   could cause the build to fail.
```
