### PR TITLE
Update to GEOSradiation_GridComp v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.10.4](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.10.4)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.8.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.8.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.17.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.17.1)                        |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.1.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.1.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.2.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.2.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.5.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.5.0)       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.2](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.2)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.1.2)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -129,7 +129,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.1.0
+  tag: v1.2.0
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates GEOSradiation_GridComp to v1.2.0. The main change here (per @dr0cloud) is extending the work from v1.1.0 that enabled production of OBIO surface solar downwelling direct and diffuse fluxes on OBIO bands. The previous release worked for RRTMG only. This release expands the facility to all three radiation codes.

It is activated by putting `SOLAR_TO_OBIO: .TRUE.` in `AGCM.rc` and then associating the solar export fields `DROBIO` and `DFOBIO` either by exporting them in history or adding future connectivity to the OradBioGC. It is off by default and therefore zero-diff. Even if it is on, it is effectively zero-diff ... it only potentially produces two currently unused new exports, now for RRTMGP and Chou-Suarez as well as for RRTMG (see https://github.com/GEOS-ESM/GEOSradiation_GridComp/pull/3).