### PR TITLE
Update to GMAO_Shared v1.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.17.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.17.1)                        |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.1.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.1.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v1.5.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv1.5.0)       |
-| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.2](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.2)                               |
+| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.3](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.3)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.1.2)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.31.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.31.0)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.6.2
+  tag: v1.6.3
   sparse: ./config/GMAO_Shared.sparse
   develop: main
 


### PR DESCRIPTION
This PR updates the GEOSgcm to GMAO_Shared v1.6.3 which has a bug fix for the `remap_restarts.py` script when remapping from MERRA-2.