### PR TITLE
Update to MAPL 2.34.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.6.3](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.6.3)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.1.2)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.34.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.34.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.34.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.34.1)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.1.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.1.0)                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.1](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.1)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -36,7 +36,7 @@ GMAO_Shared:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.34.0
+  tag: v2.34.1
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates MAPL to 2.34.1. This release has a bug fix for restart writing when `WRITE_RESTART_BY_OSERVER` is set to `YES` when writing 4d variables in restarts (as in `du_internal` and `ss_internal`). 

`WRITE_RESTART_BY_OSERVER: YES` is default only when using Open MPI, most people will not be affected. Only those using GNU as a compiler might be (which fixes issues with GOCART regression).