### PR TITLE
WIP: Move GEOS_Util to a separate repo; Update to GEOSgcm_App v1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v1.12.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v1.12.1)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.2.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.2.1)                        |
+| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v1.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v1.0.0)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v1.8.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v1.8.2)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v1.17.3](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v1.17.3)                        |

--- a/components.yaml
+++ b/components.yaml
@@ -29,8 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.6.4
+  branch: feature/mathomp4/separate-geos-util
   sparse: ./config/GMAO_Shared.sparse
+  develop: main
+
+GEOS_Util:
+  local: ./src/Shared/@GMAO_Shared/@GEOS_Util
+  remote: ../GEOS_Util.git
+  branch: main
   develop: main
 
 MAPL:


### PR DESCRIPTION
Closes #517 

This PR moves GEOS_Util to a separate repo. There will be a few steps to get this in:

- [x] Create GEOS_Util Repo → https://github.com/GEOS-ESM/GEOS_Util
- [x] Remove directories from GMAO_Shared
- [ ] Test this in the naive way (usual AMIP)
- [ ] Have @sdrabenh test this maybe with plotting something?
- [ ] Release GMAO_Shared v1.7.0
- [ ] Release GEOS_Util v1.0.0
- [ ] Update `components.yaml` here to point to tags not branches

Also, this moves GEOSgcm_App to v1.9.0. This is *NON-ZERO-DIFF* (for 2021 on?) due to the change in the NRL Solar File as well as moving to ExtData2G by default.