### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable daily updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/" # Dependabot knows to look in .github/workflows for GitHub Actions
+    schedule:
+      interval: "daily"
+
+  # Enable daily updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/.docker" # Location of Dockerfile
+    schedule:
+      interval: "daily"

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled"
+          labels: "0 diff,0 diff trivial,Non 0-diff,0 diff structural,0-diff trivial,Not 0-diff,0-diff,automatic,0-diff uncoupled,github_actions"
           add_comment: true
           message: "This PR is being prevented from merging because you have not added one of our required labels: {{ provided }}. Please add one so that the PR can be merged."
 

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Run the action
-        uses: devops-infra/action-pull-request@v0.4
+        uses: devops-infra/action-pull-request@v0.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: main

--- a/.github/workflows/release-tarball.yml
+++ b/.github/workflows/release-tarball.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           path: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
       - name: Checkout mepo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           repository: GEOS-ESM/mepo
           path: mepo

--- a/.github/workflows/trigger-circleci-pipeline-on-release.yml
+++ b/.github/workflows/trigger-circleci-pipeline-on-release.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - name: CircleCI Trigger on Release
         id: docker-build
-        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.6
         env:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}


### PR DESCRIPTION
This PR updates various GitHub Actions. The main update is adding dependabot. As we know from MAPL, dependabot can be noisy. Hopefully not too bad, but it does make us be sure to keep up to date!