### PR TITLE
Update to ESMA_cmake v3.28.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.7.0
-bcs_version: &bcs_version v10.25.0
+bcs_version: &bcs_version v11.00.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.0.1)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.27.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.27.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.28.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.28.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.0.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.0.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.27.0
+  tag: v3.28.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates to ESMA_cmake v3.28.0. This has updates for Python detection needed for MAPL `develop` (mea culpa) and pyobs work by @patricia-nasa 