### PR TITLE
Update to GOCART sdr_v2.1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.2.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.2.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
-| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.1)                        |
+| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.36.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.36.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/components.yaml
+++ b/components.yaml
@@ -91,7 +91,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: sdr_v2.1.2.1
+  tag: sdr_v2.1.2.2
   develop: develop
 
 QuickChem:


### PR DESCRIPTION
This PR updates to GOCART `sdr_v2.1.2.2`. This is non-zero-diff due to [changes in 1moment handling](https://github.com/GEOS-ESM/GOCART/commit/f4c7da3a2b1cedced27011dd66a7ef854c674630).

Note: To use GOCART2G data-driven, you'll want to update to GEOSgcm_App `develop` until GEOSgcm_App is tagged.