### PR TITLE
WIP: Latest updates for HWT Runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.2.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.2.1)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v1.1.1](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v1.1.1)                                 |
-| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.0)                       |
+| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.2](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.2)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.0.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.0.0)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.0.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.0.0)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.3.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.3.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.3.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
-| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |
+| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.3](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.3)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.37.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.37.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.36.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.36.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.37.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.37.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.1.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.1.0)                                    |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.1](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.1)                               |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.28.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.28.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.2.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.2.1)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.2.2](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.2.2)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v1.2.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v1.2.1)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v1.1.1](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v1.1.1)                                 |
@@ -26,7 +26,7 @@
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.0.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.0.0)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.0.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.0.0)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.3.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.3.0)                    |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.2.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.2.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.3.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.3.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.2.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.2.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
-| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.1)                        |
+| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.36.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.36.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  branch: develop
+  tag: v2.37.0
   develop: develop
 
 FMS:
@@ -61,13 +61,13 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.2.1
+  tag: v2.2.2
   develop: develop
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.2.0
+  tag: geos/v2.3.0
   develop: geos/develop
 
 GEOSchem_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -73,7 +73,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.12.0
+  tag: v1.12.2
   develop: develop
 
 HEMCO:
@@ -91,7 +91,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: sdr_v2.1.2.2
+  tag: sdr_v2.1.2.3
   develop: develop
 
 QuickChem:

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.36.0
+  branch: develop
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -54,7 +54,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.0.0
+  branch: develop
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
@@ -91,7 +91,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: sdr_v2.1.2.1
+  tag: sdr_v2.1.2.2
   develop: develop
 
 QuickChem:
@@ -166,7 +166,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v2.0.0
+  branch: develop
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This PR has the latest updates for HWT runs. 

NOTE: Both GEOSgcm_GridComp and GEOSgcm_App point to their `develop` branches. These will be moved to tags once code settles.

NOTE2: Moved to use MAPL `develop` as well, will go to 2.37.0 when issued.