### PR TITLE
Get rid of unused component

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -169,12 +169,6 @@ GEOSgcm_App:
   tag: v2.0.0
   develop: develop
 
-UMD_Etc:
-  local: ./src/Applications/@UMD_Etc
-  remote: ../UMD_Etc.git
-  tag: v1.2.0
-  develop: main
-
 CPLFCST_Etc:
   local: ./src/Applications/@CPLFCST_Etc
   remote: ../CPLFCST_Etc.git

--- a/src/Applications/CMakeLists.txt
+++ b/src/Applications/CMakeLists.txt
@@ -1,6 +1,5 @@
 esma_add_subdirectories(
   GEOSgcm_App
-  UMD_Etc
   CPLFCST_Etc
   )
 


### PR DESCRIPTION
This PR proposed to not clone and hence not include `UMD_Etc` going forward.

**Note**:

- It is not used by anyone who clones [GEOSgcm](git@github.com:GEOS-ESM/GEOSgcm.git)
- If someone wants it for whatever reason(s) can help themselves by cloning an release <= [v10.26.0](https://github.com/GEOS-ESM/GEOSgcm/tree/v10.26.0)


Doing ⬆️  eliminates maintenance.