### PR TITLE
Update to MAPL 2.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.8.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.8.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.36.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.36.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.38.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.38.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.1.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.1.0)                                    |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.1](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.1)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.36.0
+  tag: v2.38.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates MAPL to 2.38.0. This is mainly done now to help CI with upcoming changes from HWT work (which need the update).