### PR TITLE
Update to MAPL 2.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.0](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.0)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.6](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.6)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.38.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.38.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.0)                                    |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.1.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.1.0)                                    |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.2.1](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.2.1)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.38.1
+  tag: v2.39.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates to [MAPL 2.39.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.0).

The main fix is probably:

- `READ_RESTART_BY_FACE` has been fixed and now can read restarts from full CS grids as well as restarts that have been separated by face via `WRITE_RESTART_BY_FACE`. The current implementation requires that both `num_readers` and `num_writers` must be multiple of 6.

Zero-diff in all testing.