### PR TITLE
Bugfixes for build.csh and Moist Binary reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.29.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.29.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.3](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.3)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.3.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.3.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.0)                                 |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.29.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.29.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.2](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.2)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.3](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.3)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.3.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.3.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
@@ -24,7 +24,7 @@
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.0)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.2](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.2)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.1.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.1.2)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.1.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.1.1)                          |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.1.2](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.1.2)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.4.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.4.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.4.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.4.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.3.0
+  tag: v2.4.0
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.9.2
+  tag: v4.9.3
   develop: main
 
 cmake:
@@ -54,7 +54,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.1.1
+  tag: v2.1.2
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 


### PR DESCRIPTION
This PR has bugfixes for ESMA_env (build.csh at NAS) and GEOSgcm_GridComp (bug in binary restart reads).

It also has an update to [FVdycoreCubed_GridComp v2.4.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.0) which is trivially zero-diff as it adds code that isn't really compiled. But it might be good for @pchakraborty 's work with GPUs to get this in a tag.