### PR TITLE
Update to FVdycoreCubed_GridComp 2.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.29.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.29.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.3](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.3)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.2](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.2)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.3](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.3)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.0)                                 |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.29.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.29.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.3](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.3)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.1)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.2](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.2)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.0)                                 |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.29.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.29.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.9.3](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.9.3)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.4.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.4.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.0](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.0)                                 |

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.2
+  tag: v2.4.3
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.1
+  tag: v2.4.2
   develop: develop
 
 fvdycore:

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.4.0
+  tag: v2.4.1
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR updates GEOSgcm to FVdycoreCubed_GridComp v2.4.3. 

This has a *bugfix* to the FV3 Standalone along other more small trivial updates to FV3 GC for the FV3 standalone which [suppresses some prints](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/224) running in the standalone mode and adds pFlogger support.

ETA: Update to 2.4.3 which has support for a `--site` flag in `fv3_setup`

The GCM is not affected by this, but since we build the standalone with the GCM, might as well get the fixes in here too and not just in GEOSfvdycore.