### PR TITLE
Update to MAPL 2.39.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.7](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.7)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.4](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.4)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.5](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.5)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.0)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.4
+  tag: v2.39.5
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates to MAPL 2.39.5. This update has a bug fix for HISTORY when a user would specify an alias in HISTORY.rc for a variable with a single bin/ungridded dimension and the alias would be wrongly ignored. 

So before this:
```
'CA.brEXTTAU'    , 'CA.br'     , 'BREXTTAU'    ,
```
would lead to output of `CA.brEXTTAU001` instead of `BREXTTAU` or `BREXTTAU001`.

In MAPL 2.39.5, this will now result in a variable called `BREXTTAU` *without* the `001`. If a user desires that name, they can update the alias in HISTORY.

Beyond that fix, this is zero-diff to MAPL 2.39.4 (all other HISTORY and the state is the same)