### PR TITLE
Updates to remove Haswell at NCCS (build.csh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.30.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.30.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.17.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.17.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.18.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.18.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.5.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.17.0
+  tag: v4.18.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updating ESMA_env to v4.18.0 removes the ability to select Haswell when running `parallel_build.csh` at NCCS. It also adds a new "any" option that will build on either a Skylake or Cascade Lake...but only for Intel builds. GNU builds at NCCS use Open MPI and must build (and run) on Cascade Lake.

This is a sort of companion to https://github.com/GEOS-ESM/GEOSgcm_App/pull/489 which does something similar to the setup scripts.