### PR TITLE
Update to MAPL 2.39.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.7](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.7)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.5](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.5)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.7](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.7)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.0)                                    |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.0.2](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.0.2)                       |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.7](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.7)                                    |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.5](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.5)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.0)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.5
+  tag: v2.39.7
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOSgcm to use MAPL 2.39.7. This has two patches on top of 2.39.5:

> ## [2.39.7] - 2023-07-18
> 
> ### Fixed
> 
> - Fix a bug so that MultigroupServer does not allow a file written by multiple processes at the same time.
> 
> ## [2.39.6] - 2023-07-18
> 
> ### Changed
> 
> - Relaxed restriction in the tripolar grid factory so that grids can be made even when the decomposition deos not evenly divide the grid dimension so that the factory can be used in utilities where the core count makes such a condition impossible to satisfiy
> 
> ### Fixed
> 
> - Fix a bug in `time_ave_util.x` so that it can work with files with no vertical coordinate
> 

All testing shows it zero-diff.