### PR TITLE
Update to Baselibs 7.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.13.0
+baselibs_version: &baselibs_version v7.14.0
 bcs_version: &bcs_version v11.1.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.13.0-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v7.14.0-intelmpi_2021.6.0-intel_2022.1.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.30.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.30.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.18.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.18.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.19.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.19.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.5.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.18.0
+  tag: v4.19.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates GEOS to use Baselibs 7.14.0 (aka ESMA_env v4.19.0). This is needed for MAPL 2.40 (soon to come) but the *current* model shouldn't care as it uses MAPL 2.39 and it is zero-diff.

The updates are:

- ESMF v8.5.0
- GFE v1.11.0
  - gFTL-shared v1.6.1
  - pFUnit v4.7.3
- curl 8.2.1
- NCO 5.1.7
- CDO 2.2.1
