### PR TITLE
Update to MAPL 2.40, GEOSgcm_App v2.2.1, GEOSgcm_GridComp v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+## [11.1.1] - 2023-07-28
+
+### Zero-diff to Previous Release: YES
+### Restart Changes: NO
+
+### Major Zero-Diff Changes:
+
+* Fix GFDL Regression issue [#782](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/782)
+* Fixes for stretched grid [#476](https://github.com/GEOS-ESM/GEOSgcm_App/pull/476)
+* Add new sea ice components for coupling to `CICE6` [#772](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/772) [#478](https://github.com/GEOS-ESM/GEOSgcm_App/pull/478)
+* Set coupled ocean DT to heartbeat (for now) [#483](https://github.com/GEOS-ESM/GEOSgcm_App/pull/483)
+* Fix issue with Ocean `TerminateImport` in Surf [#789](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/789)
+* Faster river routing [#774](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/774)
+* Add `CATCHMENT_SPINUP` mode (remove snow every Aug 1 in NH or Feb 1 in SH) [#751](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/751)
+* Bug fix to correct vegetation fraction assessment in `GetIds_carbon` (getids.F90) [#770](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/770)
+* CO2 for CatchCN [#771](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/771)
+* Added support for `READ_RESTART_BY_FACE` option [#459](https://github.com/GEOS-ESM/GEOSgcm_App/pull/459)
+* Moving catchcn CO2 file to bcs dir [#481](https://github.com/GEOS-ESM/GEOSgcm_App/pull/481)
+* Boundary conditions cleanup [#786](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/786)
+* Cleanup of `make_bcs` tools that generate raster and tile files [#763](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/763)
+* Fixes for SCM Model [#725](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/725)
+* Add new `SCM` cases [#494](https://github.com/GEOS-ESM/GEOSgcm_App/pull/494)
+* Update to new SCM file dir [#477](https://github.com/GEOS-ESM/GEOSgcm_App/pull/477)
+* Fix for cloning in setup scripts [#492](https://github.com/GEOS-ESM/GEOSgcm_App/pull/492)
+* Add `gwd_internal_rst` to `gcm_regress.j` [#475](https://github.com/GEOS-ESM/GEOSgcm_App/pull/475)
+* Update `WSUB_ExtData.yaml`[#777]( https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/777)
+* Move from `FLAP` to `fArgParse` [#441](https://github.com/GEOS-ESM/GEOSgcm_App/pull/441)
+* Updates for Singularity: Add site option [#484](https://github.com/GEOS-ESM/GEOSgcm_App/pull/484)
+* Remove Haswell at NCCS, other cleanup [#489](https://github.com/GEOS-ESM/GEOSgcm_App/pull/489)
+* Fixture changes:
+   * ESMA_env  [v4.17.0 => v4.19.0](https://github.com/GEOS-ESM/ESMA_env/compare/v4.17.0...v4.19.0)
+   * ESMA_cmake  [v3.29.0 => v3.31.0](https://github.com/GEOS-ESM/ESMA_cmake/compare/v3.29.0...v3.31.0)
+   * GEOS_Util  [v2.0.0 => v2.0.2](https://github.com/GEOS-ESM/GEOS_Util/compare/v2.0.0...v2.0.2)
+   * MAPL  [v2.39.1 => v2.40.0](https://github.com/GEOS-ESM/MAPL/compare/v2.39.1...v2.40.0)
+   * GEOSgcm_GridComp  [v2.1.3 => v2.1.4](https://github.com/GEOS-ESM/GEOSgcm_GridComp/compare/v2.1.3...v2.1.4)
+   * GEOSgcm_App  [v2.2.0 => v2.2.1](https://github.com/GEOS-ESM/GEOSgcm_App/compare/v2.2.0...v2.2.1)
+   * FVdycoreCubed_GridComp  [v2.4.4 => v2.5.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/compare/v2.4.4...v2.5.0)
+   * New [icepack](https://github.com/GEOS-ESM/Icepack)
+
 ## [11.1.0] - 2023-06-08
 
 ### Zero-diff to Previous Release: NO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 11.1.0
+  VERSION 11.1.1
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.1)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.2)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.2](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.2)                       |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.0](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.0)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.1.3](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.1.3)                          |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.1)                               |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.1.4](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.1.4)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.4.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.4.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.4.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.4.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.7](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.7)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.0.2](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.0.2)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.39.7](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.39.7)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.40.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.40.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.0](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.0)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -54,7 +54,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.1.3
+  tag: v2.1.4
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
@@ -176,7 +176,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v2.2.0
+  tag: v2.2.1
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.39.7
+  tag: v2.40.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOS to MAPL 2.40. Due to #625, we now require this. Mea culpa. All tests show it to be zero-diff to MAPL 2.39

We also update to GEOSgcm_App v2.2.1 and GEOSgcm_GridComp v2.1.4