### PR TITLE
Update to GEOSradiation_GridComp v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.12.2](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.12.2)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.1.4](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.1.4)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.4.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.4.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.0.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.0.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.1)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -163,7 +163,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.5.0
+  tag: v1.5.1
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates to GEOSradiation_GridComp v1.5.1 which has a bugfix for the user-selectable RRTMGP T_MIN_OK parameter. This is zero-diff if you aren't using RRTMGP (and zero-diff if you are and don't change it).