### PR TITLE
update Icepack to geos/v0.0.3 with a bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.1)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.1.2.7](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.1.2.7)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.0.2](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.0.2)                       |
+| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.0.3](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.0.3)                       |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.40.3](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.40.3)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/components.yaml
+++ b/components.yaml
@@ -151,7 +151,7 @@ cice6:
 icepack:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6/icepack
   remote: ../Icepack.git
-  tag: geos/v0.0.2
+  tag: geos/v0.0.3
   develop: geos/develop
 
 sis2:


### PR DESCRIPTION
This PR updates to Icepack geos/v0.0.3 which has a bug fix. This is trivially zero-diff (it only affects coupled runs with CICE6).