### PR TITLE
Add ignore_submodules to cice

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -147,6 +147,7 @@ cice6:
   remote: ../CICE.git
   tag: geos/v0.0.2
   develop: geos/develop
+  ignore_submodules: true
 
 icepack:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6/icepack


### PR DESCRIPTION
This PR adds `ignore_submodules: true` for CICE in GEOSgcm. This enables a new feature of mepo which should prevent `mepo status` from showing:

```
cice6                  | (t) geos/v0.0.2 (DH)
   | icepack: modified, not staged
```

as well as `mepo diff` from showing a difference as well. We see this because *git* sees it since `git status` and `git diff` know that `icepack` was/is a submodule of CICE but we are "ignoring" it and not using it...but git doesn't know that.

So with this change, we can register with mepo that cice should run `status` and `diff` ignoring submodule changes.

I'll keep draft for now until I can test and ideally @zhaobin74 can test (since I really don't want to mess up his code). I think it's all good in my testing.

Note if you build locally, you want to get mepo v1.51.1 (or just `main`) to see this working. I've updated the mepo versions at NCCS and NAS so we should be good...