### PR TITLE
Update to BCs 11.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.14.0
-bcs_version: &bcs_version v11.1.0
+bcs_version: &bcs_version v11.2.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:


### PR DESCRIPTION
Very boring PR. Updates the CI to use BCs v11.2.0.