### PR TITLE
update CICE6 to geos/v0.1.0 with new C-EVP feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Repository                                                                     | Version                                                                                             |
 | ----------                                                                     | -------                                                                                             |
-| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.0.2](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.0.2)                          |
+| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.34.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.34.0)                              |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.3)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.2)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.2.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.2.0)                          |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.2.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.2.1)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.4.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.4.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |

--- a/components.yaml
+++ b/components.yaml
@@ -145,7 +145,7 @@ mit:
 cice6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6
   remote: ../CICE.git
-  tag: geos/v0.0.2
+  tag: geos/v0.1.0
   develop: geos/develop
   ignore_submodules: true
 

--- a/components.yaml
+++ b/components.yaml
@@ -54,7 +54,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.2.0
+  tag: v2.2.1
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 


### PR DESCRIPTION
This PR updates to CICE6 geos/v0.1.0 which enabled a new feature: C-EVP dynamic scheme. This is trivially zero-diff (it only affects coupled runs with CICE6).

Depends on https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/824