### PR TITLE
Updates from HWT Experiments (Non-zero-diff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## [11.3.0] - 2023-09-29
+
+### Zero-diff to Previous Release: NO
+### Restart Changes: NO
+
+### Major Non-Zero-Diff Changes:
+* Change default parameters to reduce 900mb T/Q forecast RMSE [#835](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/835)
+* Updates to `fv_mapz.F90` in fvdycore  [v2.5.0 => v2.6.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/compare/geos/v2.5.0...geos/v2.6.0)
+
 ## [11.2.1] - 2023-09-29
 
 ### Zero-diff to Previous Release: YES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 11.2.1
+  VERSION 11.3.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.3)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.3](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.3)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.2.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.2.1)                          |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.3.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.3.0)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.5.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.5.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.6.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.6.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.4](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.4)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.2.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -54,7 +54,7 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.2.1
+  tag: v2.3.0
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 
@@ -67,7 +67,7 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.5.0
+  tag: geos/v2.6.0
   develop: geos/develop
 
 GEOSchem_GridComp:


### PR DESCRIPTION
This PR has non-zero-diff updates from HWT experiments:

- GEOSgcm_GridComp v2.2.1 → v2.3.0
- GFDL_atmos_cubed_sphere geos/v2.5.0 → geos/v2.6.0