### PR TITLE
update icepack to geos/v0.1.1 with a patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.4](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.4)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.2.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.1.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.1.0)                       |
+| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.1.1](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.1.1)                       |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.41.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.41.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/components.yaml
+++ b/components.yaml
@@ -152,7 +152,7 @@ cice6:
 icepack:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6/icepack
   remote: ../Icepack.git
-  tag: geos/v0.1.0
+  tag: geos/v0.1.1
   develop: geos/develop
 
 sis2:


### PR DESCRIPTION
This PR updates icepack to geos/v0.1.1. This was a patch fixing a bug causing the crash in 1440x1080 configuration. See https://github.com/GEOS-ESM/Icepack/pull/3 for details. This is trivially zero-diff (it only affects coupled runs with CICE6).