### PR TITLE
update cice6 to geos/v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Repository                                                                     | Version                                                                                             |
 | ----------                                                                     | -------                                                                                             |
-| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.1](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.1)                          |
+| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.2](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.2)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.35.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.35.0)                              |

--- a/components.yaml
+++ b/components.yaml
@@ -145,7 +145,7 @@ mit:
 cice6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6
   remote: ../CICE.git
-  tag: geos/v0.1.1
+  tag: geos/v0.1.2
   develop: geos/develop
   ignore_submodules: true
 


### PR DESCRIPTION
This PR updates to ```CICE6``` ```geos/v0.1.2``` which has a minor fix allowing high resolution ```CICE6``` coupled runs to keep all-land blocks on all processors. This is trivially **zero-diff** (it only affects coupled runs with ```CICE6```).