### PR TITLE
Update GEOSgcm_App to v2.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.3](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.3)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.3)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.4)                               |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.5](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.5)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.3.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.3.1)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.6.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.6.0)       |

--- a/components.yaml
+++ b/components.yaml
@@ -177,7 +177,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v2.2.4
+  tag: v2.2.5
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This PR updates GEOSgcm to use GEOSgcm_App v2.2.5 which has some fixes for running on macOS.