### PR TITLE
Update to ESMA_cmake v3.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.2](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.2)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.35.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.35.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.36.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.36.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.20.4](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.20.4)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.8.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.35.0
+  tag: v3.36.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates to ESMA_cmake v3.36.0. This has fixes for building on macOS under Rosetta with Intel as well as a fix for building with `icx`.

Neither of these are used by the usual ways of building GEOS but rather in ongoing development testing.