### PR TITLE
Update CI BCs to v11.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.14.0
-bcs_version: &bcs_version v11.2.0
+bcs_version: &bcs_version v11.3.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:


### PR DESCRIPTION
An upcoming PR from @sanAkel (see https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/47) will need an update to CI BCs. This is trying to preempt that issue here.