### PR TITLE
Update to fvdycore geos/v2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.6](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.6)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.3.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.3.1)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.6.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.6.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.6](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.6)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.2.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.6.0
+  tag: geos/v2.7.0
   develop: geos/develop
 
 GEOSchem_GridComp:


### PR DESCRIPTION
This PR updates GEOS to use [fvdycore geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0). This is zero-diff for GEOSgcm as it adds support for a by-default-off new way of computing coordinates.

This is a companion PR to https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/258 and https://github.com/GEOS-ESM/GEOSgcm_App/pull/535. Both of these use the new namelist parameter added in fvdycore geos/v2.7.0. But we can't add that flag until we have the Fortran to support it.

Thus, we get this in first, then we can dribble in the other two PRs.