### PR TITLE
Update to FVdycoreCubed_GridComp v2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.36.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.36.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.20.6](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.20.6)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.8.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.8.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.9.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.9.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.3](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.3)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.3)                                 |

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.8.0
+  tag: v2.9.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
Update to FVdycoreCubed_GridComp v2.9.0 which simply adds a line to a namelist heredoc in `fv3.j`.

Note that this *REQUIRES* [GFDL_atmos_cubed_sphere geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0) but that is in `main` now (see #696)
