### PR TITLE
update cice6 to geos/v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 | Repository                                                                     | Version                                                                                             |
 | ----------                                                                     | -------                                                                                             |
-| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.2](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.2)                          |
+| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.3](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.3)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.36.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.36.0)                              |

--- a/components.yaml
+++ b/components.yaml
@@ -145,7 +145,7 @@ mit:
 cice6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6
   remote: ../CICE.git
-  tag: geos/v0.1.2
+  tag: geos/v0.1.3
   develop: geos/develop
   ignore_submodules: true
 


### PR DESCRIPTION
This PR updates to CICE6 geos/v0.1.3 which adds support for running CICE6 in replay mode. This is trivially zero-diff (it only affects coupled runs with CICE6).