### PR TITLE
Update to fvdycore geos/v2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.7](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.7)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.3.2](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.3.2)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0)       |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.8.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.8.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.6](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.6)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.2.1](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.2.1)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ FVdycoreCubed_GridComp:
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: geos/v2.7.0
+  tag: geos/v2.8.0
   develop: geos/develop
 
 GEOSchem_GridComp:


### PR DESCRIPTION
Closes #654 

This PR updates fvdycore to geos/v2.8.0. This has a fix from @aoloso for the layout non-reproducibility at C180+. Huzzah!

All tests show at low-res it is zero-diff. 