### PR TITLE
WIP: Separate ncar_gwd into its own repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.3)                                    |
+| [ncar_gwd](https://github.com/GEOS-ESM/ncar_gwd)                               | [v1.0.0](https://github.com/GEOS-ESM/ncar_gwd/releases/tag/v1.0.0)                                  |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.6+1.1.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.6%2B1.1.0)          |

--- a/components.yaml
+++ b/components.yaml
@@ -54,8 +54,14 @@ FMS:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v2.3.2
+  branch: feature/mathomp4/separate-ncar-gwd
   sparse: ./config/GEOSgcm_GridComp.sparse
+  develop: develop
+
+ncar_gwd:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSgwd_GridComp/@ncar_gwd
+  remote: ../ncar_gwd.git
+  branch: main
   develop: develop
 
 FVdycoreCubed_GridComp:


### PR DESCRIPTION
This PR is in conjunction with https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/864

It moves ncar_gwd out into its own repo per a request of @wmputman 