### PR TITLE
Update to GEOSradiation_GridComp v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.2.8](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.2.8)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.4.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.4.0)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.5.1](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.5.1)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.6.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.8.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.8.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.6](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.6)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -164,7 +164,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.5.1
+  tag: v1.6.0
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates to GEOSradiation_GridComp v1.6.0. This release of GEOSradiation_GridComp has a few updates (see https://github.com/GEOS-ESM/GEOSradiation_GridComp/pull/27):

1. The Load Balancing code in Solar was reworked to not call MAPL_LoadBalance code when not load balancing. Previously, it used a naive approach which still did MPI calls for no reason. Now it avoids that.
2. Adds the ability to change the `MaxPasses` parameter when loadbalancing via the `SOLAR_LB_MAX_PASSES:` AGCM.rc resource. By default it uses 100 which is the default in MAPL
3. Fixes for the profilers. Testing by @wmputman and @atrayano at high-res found that some columns over an integration period might not have, say, any clouds. This would then avoid some code in RRTMG which meant some timers were not turned on-off on some processes. This lead to deadlocks in Finalize when the timers were outputted. Likewise, when the loadbalaning code was updated, it found that processes without lit points also avoided some profiler calls.

All testing shows this is zero-diff to GEOSradiaiton_GridComp v1.5.1