### PR TITLE
Update to ESMA_env v4.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.36.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.36.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.24.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.24.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.25.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.25.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.9.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.9.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v4.24.0
+  tag: v4.25.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates GEOSgcm to ESMA_env v4.25.0 which is:

- Moved to Baselibs 7.17.1
  - Fix for NAG and ESMF 8.6.0
- Update `g5_modules` to use GCC 11.4 as the backing C compiler on SLES 15 at NCCS
  - This was done as it was discovered that xgboost was not building on SLES15 with Intel when using GCC 12. Until xgboost can be
    updated to a newer version, this is the workaround.
