### PR TITLE
update Icepack to turn on dEdd shortwave scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.7](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.7)                               |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
-| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.1.1](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.1.1)                       |
+| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.2.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.2.0)                       |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.43.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.43.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |

--- a/components.yaml
+++ b/components.yaml
@@ -152,7 +152,7 @@ cice6:
 icepack:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6/icepack
   remote: ../Icepack.git
-  tag: geos/v0.1.1
+  tag: geos/v0.2.0
   develop: geos/develop
 
 sis2:


### PR DESCRIPTION
This PR updates icepack to geos/v0.2.0. This update includes code to enable delta Eddington shortwave scheme.  This is trivially zero-diff (it only affects coupled runs with CICE6).