### PR TITLE
Add Special NCCS Build Preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ parallel_build.o*
 log.*
 CMakeUserPresets.json
 
+# Ignore possible symlinked directories
+build-*
+install-*
+
 *.swp
 *.swo
 .DS_Store

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,22 +1,14 @@
 ﻿{
-  "version": 3,
+  "version": 7,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 27,
     "patch": 0
   },
+  "include": [
+    "presets/CMake$penv{CMAKE_PRESET_NAME}Presets.json"
+  ],
   "configurePresets": [
-    {
-      "name": "base-configure",
-      "hidden": true,
-      "displayName": "Base Configure Settings",
-      "description": "Sets build and install directories",
-      "binaryDir": "${sourceDir}/build-${presetName}",
-      "cacheVariables": {
-        "BASEDIR": "$env{BASEDIR}",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install-${presetName}"
-      }
-    },
     {
       "name": "base-gnu",
       "hidden": true,

--- a/presets/CMakeDefaultPresets.json
+++ b/presets/CMakeDefaultPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "installDir": "${sourceDir}/install-${presetName}"
+    }
+  ],
+  "version": 7
+}

--- a/presets/CMakeNCCSPresets.json
+++ b/presets/CMakeNCCSPresets.json
@@ -1,0 +1,13 @@
+﻿{
+  "configurePresets": [
+    {
+      "name": "base-configure",
+      "hidden": true,
+      "displayName": "Base Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "$penv{CMAKE_BUILD_LOCATION}/${sourceDirName}/build-${presetName}",
+      "installDir": "$penv{CMAKE_INSTALL_LOCATION}/${sourceDirName}/install-${presetName}",
+    }
+  ],
+  "version": 7
+}

--- a/presets/CMakeNCCSPresets.json
+++ b/presets/CMakeNCCSPresets.json
@@ -6,7 +6,7 @@
       "displayName": "Base Configure Settings",
       "description": "Sets build and install directories",
       "binaryDir": "$penv{CMAKE_BUILD_LOCATION}/${sourceDirName}/build-${presetName}",
-      "installDir": "$penv{CMAKE_INSTALL_LOCATION}/${sourceDirName}/install-${presetName}",
+      "installDir": "$penv{CMAKE_INSTALL_LOCATION}/${sourceDirName}/install-${presetName}"
     }
   ],
   "version": 7


### PR DESCRIPTION
This is an attempt to change the build pattern using `CMakePresets.json` to work smarter at NCCS. If this works, let say you have a checkout of GEOSgcm in:
```
/discover/swdev/mathomp4/Models/GEOSgcm-FixPresets
```
along with the following environment variables (with examples for me):
```
CMAKE_PRESET_NAME=NCCS
CMAKE_BUILD_LOCATION=/discover/nobackup/projects/gmao/SIteam/mathomp4/cmake-builds
CMAKE_INSTALL_LOCATION=/discover/nobackup/projects/gmao/SIteam/mathomp4/cmake-installs
```

Then when you do:
```
cmake --preset Debug && cmake --build --preset Debug -j 10
```
it will put the build dir in:
```
/discover/nobackup/projects/gmao/SIteam/mathomp4/cmake-installs/GEOSgcm-FixPresets/build-Debug
```
and installs to:
```
/discover/nobackup/projects/gmao/SIteam/mathomp4/cmake-installs/GEOSgcm-FixPresets/install-Debug
```

The other style is used by setting:
```
export CMAKE_PRESET_NAME=Default
```

This triggers the "old" way where builds will be at the root of the build. So if the code is in:
```
/discover/swdev/mathomp4/Models/GEOSgcm-FixPresets
```
then you'll get:
```
/discover/swdev/mathomp4/Models/GEOSgcm-FixPresets/build-Debug
/discover/swdev/mathomp4/Models/GEOSgcm-FixPresets/install-Debug
```

Note: This takes discipline as it uses the `sourceDirName` for a build. That is, the name of the directory holding the code, so for `/discover/swdev/mathomp4/Models/GEOSgcm-FixPresets`, it uses `GEOSgcm-FixPresets`.