### PR TITLE
Update to MAPL 2.44.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.1.1](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.1.1)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.43.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.43.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.44.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.3)                                    |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.43.1
+  tag: v2.44.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOSgcm to MAPL 2.44.0. This requires updated ESMA_env and ESMA_cmake, but both versions are already in GEOSgcm `main`:

- ESMA_env v4.25.0 → #730 
- ESMA_cmake v3.40.0 → #746 

The [changes in MAPL 2.44](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.0) are manyfold, but it is zero-diff. Indeed, one change (from MAPL 2.43.2) is a fix for a memory leak!