### PR TITLE
Update to ESMA_cmake v3.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.3](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.3)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.40.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.40.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.41.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.25.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.25.1)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.10.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.10.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.40.0
+  tag: v3.41.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates ESMA_cmake to [v3.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.41.0). The main purpose for this is to set the MPI Stack by CMake rather than by looking at `$BASEDIR` which will not be feasible for Spack use.

This is a prerequisite for an other PR upcoming in GEOSgcm_App but which can't work without this PR.