### PR TITLE
Update to FVdycoreCubed_GridComp v2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.41.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.25.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.25.1)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.10.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.10.0)                    |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.5](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.5)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.5](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.5)                                 |

--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOSgcm_GridComp:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: v2.10.0
+  tag: v2.11.0
   develop: develop
 
 fvdycore:


### PR DESCRIPTION
This PR update GEOSgcm to use FVdycoreCubed_GridComp. The [main change](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/compare/v2.10.0...v2.11.0) is changing `fv3_setup` to use CMake rather than `$BASEDIR` to detect MPI stack (cf https://github.com/GEOS-ESM/GEOSgcm_App/pull/580)

There is also some CI stuff that doesn't matter. 😄 
