### PR TITLE
Update to GEOSradiation_GridComp v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.5.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.5.1)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.6.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.7.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.7.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.8.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.8.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.7](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.7)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -164,7 +164,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.6.0
+  tag: v1.7.0
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates GEOSgcm to use [GEOSradiation_GridComp v1.7.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.7.0). There are two main changes in this from v1.6.0.

The first is a small change needed for ongoing OceanBioGeoChem work (#28). To use this completely needs updates in GEOSgcm_GridComp and GOCART. Contact @mfmehari for more information.

The second is an update for on-going validation of RRTMGP (#33). This adds a new CMake option, `ENABLE_SOLAR_RADVAL` which is default `OFF`. Enabling it will enable many new exports for validation purposes. 

This update is non-zero-diff for RRTMGP but that is not run by default currently. For RRTMG they are either zero-diff or 'truncation zero-diff', but these changes should only affect diagnostic outputs. That said, the Solar Internal Restart will have some changes (see below) but the overall state of the model is zero-diff with RRTMG:

- Metadata changes (`long_name`)
  - `CLDHISW`: "high-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "high-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDLOSW`: "low-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "low-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDMDSW`: "mid-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "mid-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDTTSW`: "total_cloud_area_fraction_rrtmg_sw_REFRESH" → "total_cloud_area_fraction_RRTMG_P_SW_REFRESH"
- Removed fields
  - `TAUHIPAR`
  - `TAULOPAR`
  - `TAUMDPAR`
  - `TAUTTPAR`
- Added fields
  - `COTDENHIPAR`
  - `COTDENLOPAR`
  - `COTDENMDPAR`
  - `COTDENTTPAR` 
  - `COTHIPAR`
  - `COTLOPAR`
  - `COTMDPAR`
  - `COTTTPAR`
  - `COTNUMHIPAR`
  - `COTNUMLOPAR`
  - `COTNUMMDPAR` 
  - `COTNUMTTPAR`