### PR TITLE
Update to RRTMGP v1.7, GEOSradiation_GridComp v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.5](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.5)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.7](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.7)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.1)                               |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.2)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.5.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.5.1)                          |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.8.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.8.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.8.1)       |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.1](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.1)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.5.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.5.1)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.6.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.6.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.8.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.8.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.8.1)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.1.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.1.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.7](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.7)                               |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v2.2.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v2.2.3)                                    |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
-| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.6+1.1.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.6%2B1.1.0)          |
+| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.7+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)          |
 | [SIS2](https://github.com/GEOS-ESM/SIS2)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/SIS2/releases/tag/geos%2Fv0.0.1)                          |
 | [StratChem](https://github.com/GEOS-ESM/StratChem)                             | [v1.0.0](https://github.com/GEOS-ESM/StratChem/releases/tag/v1.0.0)                                 |
 | [TR](https://github.com/GEOS-ESM/TR)                                           | [v1.1.0](https://github.com/GEOS-ESM/TR/releases/tag/v1.1.0)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -164,13 +164,13 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.6.0
+  branch: feature/pnorris/RRTMGP_v1.7
   develop: develop
 
 RRTMGP:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp/GEOS_RadiationShared/@RRTMGP
   remote: ../rte-rrtmgp.git
-  tag: geos/v1.6+1.1.0
+  tag: geos/v1.7+1.0.0
   develop: geos/develop
   sparse: ./config/RRTMGP.sparse
 
@@ -189,7 +189,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v2.3.1
+  branch: feature/pnorris/RRTMGP_v1.7
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -164,7 +164,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  branch: feature/pnorris/RRTMGP_v1.7
+  tag: v1.8.0
   develop: develop
 
 RRTMGP:

--- a/components.yaml
+++ b/components.yaml
@@ -189,7 +189,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: feature/pnorris/RRTMGP_v1.7
+  tag: v2.3.2
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This is a meta-PR for updating the components in GEOSgcm to use RRTMGP v1.7 which requires an updated GEOSradiation_GridComp as well:

- [RRTMGP v1.7](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)
- [GEOSradiation_GridComp v1.8.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.8.0)

To *run* RRTMGP v1.7 you also need a change in GEOSgcm_App currently in a PR: https://github.com/GEOS-ESM/GEOSgcm_App/pull/585

This is zero-diff for RRTMG runs, only changes RRTMGP runs.

Note also that RRTMGP v1.7 can be run in Single Precision mode with the CMake option:
```
-DRRTMGP_SINGLE_PRECISION=ON
```
Tests show that single-precision RRTMGP is about [10-20% faster than DP](https://github.com/GEOS-ESM/GEOSradiation_GridComp/pull/36#issuecomment-1971606964). But, for now we are keeping the default build to be double precision by default until further testing. Per @dr0cloud:
> I have noticed around a -0.15W/m2 difference in global OSR in SP mode, but individual clouds can be -2 W/m2 or more.

---

## Updates from GEOSradiation_GridComp v1.7

The above v1.8 tag also brings along updates from v1.7. As listed in #756, this also has effects.

The first is a small change needed for ongoing OceanBioGeoChem work (#28). To use this completely needs updates in GEOSgcm_GridComp and GOCART. Contact @mfmehari for more information.

The second is an update for on-going validation of RRTMGP (#33). This adds a new CMake option, `ENABLE_SOLAR_RADVAL` which is default `OFF`. Enabling it will enable many new exports for validation purposes. 

This update is non-zero-diff for RRTMGP but that is not run by default currently. For RRTMG they are either zero-diff or 'truncation zero-diff', but these changes should only affect diagnostic outputs. That said, the Solar Internal Restart will have some changes (see below) but the overall state of the model is zero-diff with RRTMG:

- Metadata changes (`long_name`)
  - `CLDHISW`: "high-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "high-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDLOSW`: "low-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "low-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDMDSW`: "mid-level_cloud_area_fraction_rrtmg_sw_REFRESH" → "mid-level_cloud_area_fraction_RRTMG_P_SW_REFRESH"
  - `CLDTTSW`: "total_cloud_area_fraction_rrtmg_sw_REFRESH" → "total_cloud_area_fraction_RRTMG_P_SW_REFRESH"
- Removed fields
  - `TAUHIPAR`
  - `TAULOPAR`
  - `TAUMDPAR`
  - `TAUTTPAR`
- Added fields
  - `COTDENHIPAR`
  - `COTDENLOPAR`
  - `COTDENMDPAR`
  - `COTDENTTPAR` 
  - `COTHIPAR`
  - `COTLOPAR`
  - `COTMDPAR`
  - `COTTTPAR`
  - `COTNUMHIPAR`
  - `COTNUMLOPAR`
  - `COTNUMMDPAR` 
  - `COTNUMTTPAR`

