### PR TITLE
Fix up MPI detection for Spack builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,16 @@ foreach (dir cmake @cmake cmake@)
     set (ESMA_CMAKE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}" CACHE PATH "Path to ESMA_cmake code")
   endif ()
 endforeach ()
+
+# We need to find MPI before we go into esma
+# for the MPI stack detection to work
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package(MPI)
+
 include (esma)
 
 # Add CMake for when not using Baselibs
 if (NOT Baselibs_FOUND)
-  set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-  find_package(MPI)
 
   find_package(NetCDF REQUIRED C Fortran)
   add_definitions(-DHAS_NETCDF4)


### PR DESCRIPTION
Testing by @sanAkel found an issue with building GEOS with spack as libraries. This fixes that issue.

Trivially zero-diff as CMake works or won't.