### PR TITLE
Update to MAPL 2.44.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.2.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.2.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.44.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.44.2](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.2)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.1](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.1)                                        |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.1](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.1)                                    |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.2.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.2.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.44.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.44.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.44.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.1](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.1)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.44.0
+  tag: v2.44.1
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.44.1
+  tag: v2.44.2
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates GEOSgcm to MAPL 2.44.2. 

MAPL 2.44.1 is a patch on MAPL 2.44.0 which fixes a bug when users have instantaneous, bit-shaved binary HISTORY output that isn't purely diagnostic. In this case, it is non-zero-diff, but we know of no users of GEOSgcm using binary history output, so I'm listing as zero-diff. 

MAPL 2.44.2 has a bug fix for `time_ave_util.x` for when the input files have a level size of 1. This is trivially zero-diff until https://github.com/GEOS-ESM/GEOS_Util/pull/29 can be tested and merged in by @sdrabenh or @Jcampbell-8 or someone. But at least we know `time_ave_util.x` works better now!