### PR TITLE
Update to ESMA_cmake v3.44.0 and GEOS_Util v2.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.3](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.3)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.41.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.44.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.44.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.25.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.25.1)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.8](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.8) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.6](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.6)                        |
-| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.7](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.7)                                 |
+| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.8](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.8)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.2](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.2)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.5.2](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.5.2)                          |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.41.0
+  tag: v3.44.0
   develop: develop
 
 ecbuild:
@@ -36,7 +36,7 @@ GMAO_Shared:
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  tag: v2.0.7
+  tag: v2.0.8
   develop: main
 
 MAPL:


### PR DESCRIPTION
This PR updates the SLES15 detection such that if the model is not built on SLES15, then the `BUILT_ON_SLES15` CMake variable will now be `FALSE` instead of a blank string.

This PR also then updates to GEOS_Util v2.0.8 which has a fix for `remap_restarts.py` to work with the new `BUILT_ON_SLES15` being `FALSE`.

NOTE: The other updates from ESMA_cmake v3.41 to v3.44 are for MAPL only (NAG flags and changes to tests).