### PR TITLE
Update to ESMA_cmake v3.45.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.1.3](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.1.3)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.45.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.45.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.28.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.28.1)                                |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.45.2](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.45.2)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.29.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.29.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.45.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.45.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.28.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.28.1)                                |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.45.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.45.1)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.45.2](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.45.2)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.29.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.29.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.45.1
+  tag: v3.45.2
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
As found by @climbfuji, there was a bug in the CMake for macOS on machines with older XCode. I'd hardcoded in "use ld_classic" but that's not needed on all macs.

This update fixes that.