### PR TITLE
Updates for v11.5.3 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v7.24.0
-bcs_version: &bcs_version v11.3.0
+bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.24.0
+baselibs_version: &baselibs_version v7.23.0
 bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 


### PR DESCRIPTION
This PR will have updates for v11.5.3. For now, it updates the CI so that it works with the soon to be updated GEOSgcm_App with v12 BCs support.