### PR TITLE
Update Radiation GC to more stable branch

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -158,7 +158,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  branch: feature/pnorris/OSR_per_band_instrumentation-merge-scott
+  branch: feature/sdrabenh/gcm_v12-rc1
   develop: feature/sdrabenh/gcm_v12-rc1
 
 RRTMGP:


### PR DESCRIPTION
I noticed that the `feature/sdrabenh/gcm_v12-rc1` branch is now pointing to a branch of radiation that might be deleted at some point. So we instead point it to `feature/sdrabenh/gcm_v12-rc1` until a tag is made.

