### PR TITLE
Update to MAPL 2.47.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.46.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.46.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.47.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.47.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.1](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.1)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.46.1
+  tag: v2.47.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This updates GEOSgcm to [MAPL 2.47.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.47.0). All testing shows this is zero-diff to MAPL 2.46. 

Probably the main updates to 2.47.0 are:

- Updates to the station sampler code by @metdyn to make it faster
- Added capability to mangle `LONG_NAME` in ACG with a different prefix by @darianboggs 

The latter was requested by @acollow for work in M21C (see #792) and FP and elsewhere. To use it will require a change to GOCART a la https://github.com/GEOS-ESM/GOCART/pull/278. Of course, for current GEOSgcm, this will need to be done relative our GOCART sdr_v2.2.1.2 (aka a new sdr_v2.2.1.3 I suppose).