### PR TITLE
Update CI Baselibs to 7.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.23.0
+baselibs_version: &baselibs_version v7.25.0
 bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
@@ -84,9 +84,9 @@ workflows:
           bcs_version: *bcs_version
           container_name: geosgcm
           mpi_name: intelmpi
-          mpi_version: 2021.6.0
+          mpi_version: "2021.13"
           compiler_name: intel
-          compiler_version: 2022.1.0
+          compiler_version: "2024.2"
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.24.0-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.13-intel_2024.2
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests


### PR DESCRIPTION
This PR updates the CI to 7.25.0. Mainly for MAPL3 work, but we move regardless