### PR TITLE
v12: Update FMS CMake target, Baselibs 8.5.0, and more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v8.0.2
+baselibs_version: &baselibs_version v8.5.0
 bcs_version: &bcs_version v11.5.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v8.0.2-intelmpi_2021.6.0-intel_2022.1.0
+      image: gmao/ubuntu20-geos-env:v8.5.0-intelmpi_2021.13-intel_2024.2
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   GEOSgcm
-  VERSION 11.6.1
+  VERSION 12.0.0
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -81,9 +81,18 @@ if (NOT Baselibs_FOUND)
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
   find_package(FMS REQUIRED COMPONENTS R4 R8)
-  # We need aliases due to historical reasons
-  add_library(fms_r4 ALIAS FMS::fms_r4)
-  add_library(fms_r8 ALIAS FMS::fms_r8)
+
+  # At the moment, there is no way to know if FMS was built with YAML
+  # so we need to rely on the user to set this option.
+  option(FMS_BUILT_WITH_YAML "FMS was built with YAML" OFF)
+  if (FMS_BUILT_WITH_YAML)
+    # We use the same Findlibyaml.cmake that FMS uses
+    find_package(libyaml REQUIRED)
+    message(STATUS "LIBYAML_INCLUDE_DIR: ${LIBYAML_INCLUDE_DIR}")
+    message(STATUS "LIBYAML_LIBRARIES: ${LIBYAML_LIBRARIES}")
+    target_link_libraries(FMS::fms_r4 INTERFACE ${LIBYAML_LIBRARIES})
+    target_link_libraries(FMS::fms_r8 INTERFACE ${LIBYAML_LIBRARIES})
+  endif ()
 
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -15,28 +15,15 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-<<<<<<< HEAD
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.0.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.0.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.0.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.0.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.5.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.5.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.3.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.3.0)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.7](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.7)                        |
-| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.0.8](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.0.8)                                 |
-| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.13.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.13.1)                       |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.3](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.3)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.0)                          |
-=======
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.48.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.48.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.29.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.29.0)                                |
-| [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
-| [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.1.6](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.1.6)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.2)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.1)                          |
->>>>>>> origin/main
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.8.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.9.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.9.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.3.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.3.0)                                       |
@@ -46,8 +33,8 @@
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.47.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.47.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
-| [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+2.0.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B2.0.0)              |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.1](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.1)                                        |
+| [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+2.1.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B2.1.0)              |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.2](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.2)                                        |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.8+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.8%2B1.0.0)          |

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.0.0
+  tag: v5.3.0
   develop: main
 
 cmake:
   local: ./@cmake
-  remote: ../ESMA_cmake.git 
-  tag: v4.0.0
+  remote: ../ESMA_cmake.git
+  tag: v4.5.0
   develop: develop
 
 ecbuild:
@@ -115,19 +115,19 @@ StratChem:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.0.0
+  tag: v3.3.0
   develop: develop
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM_GEOS5PlugMod/@mom
   remote: ../MOM5.git
-  tag: geos/5.1.0+2.0.0
+  tag: geos/5.1.0+2.1.0
   develop: geos5
 
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v3.1
+  tag: geos/v3.2
   develop: main
   recurse_submodules: true
 

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -3,13 +3,3 @@ esma_add_subdirectories (
   GMAO_Shared
   NCEP_Shared
   )
-
-if (NOT FMS_FOUND)
-  message (STATUS "FMS library not found. Building FMS from source.")
-  # Special case - FMS is built twice with two
-  # different precisions.
-  esma_add_subdirectory (FMS RENAME fms_r4)
-  esma_add_subdirectory (FMS RENAME fms_r8)
-else ()
-  message (STATUS "FMS library found. Using FMS from ${FMS_DIR}")
-endif ()


### PR DESCRIPTION
As we move to FMS in Baselibs, we shouldn't use the old `fms_r4` and `fms_r8` targets
anymore as they are non-standard. Instead we move to `FMS::fms_r4` and `FMS::fms_r8`.

This also adds a preliminary shot at supporting FMS with YAML support, although this has not been tested.

We also update to ESMA_cmake v4.5.0 to bring in a new cmake function (needed for MAPL 3), a fix for Spack work, and a NAG workaround.

We also update to ESMA_env v5.3.0 which brings in Baselibs 8.5.0 and Intel ifort 2021.13

We also update to MOM6 geos/v3.2 and Ocean GC v3.3.0. 

NOTE NOTE NOTE: The ESMA_env update is zero-diff for the *state* but non-zero-diff for *history*. Not sure why, but I have confirmed it's due to the compiler update. But this update is needed.