### PR TITLE
Update to GEOSradiation_GridComp v1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.1)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.8.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.8.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.9.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.9.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.9.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.9.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.3.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.3.0)                                       |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.8](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.8)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -164,7 +164,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.8.0
+  tag: v1.9.0
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates GEOSradiation_GridComp to v1.9.0. This release has a bugfix to Solar that is zero-diff to the state. If a user somehow requested certain exports, it's possible the history output could be non-zero-diff, but the trigger for the bug was causing 0/0 NaNs.

It also has minor CMake changes and adds in some preprocessing scripts.