### PR TITLE
Update to ESMA_cmake v4.6.0, ESMA_env v5.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,7 @@ bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:f0c2c8ef70b5b840bbd8e08f6fabaa9f7bb4d5d4
-  #ci: geos-esm/circleci-tools@5
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,12 @@ parameters:
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
 baselibs_version: &baselibs_version v8.5.0
-bcs_version: &bcs_version v11.5.0
+bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:
-  ci: geos-esm/circleci-tools@3
+  ci: geos-esm/circleci-tools@dev:9428a6bb28aa2f1623927873a863dcd381d55bd0
+  #ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -45,11 +46,11 @@ workflows:
           matrix:
             parameters:
               compiler: [gfortran, ifort]
-          baselibs_version: *baselibs_version
-          bcs_version: *bcs_version
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
 
       # Run Coupled GCM (1 hour, no ExtData)
       - ci/run_gcm:
@@ -59,11 +60,11 @@ workflows:
           matrix:
             parameters:
               compiler: [ifort]
-          baselibs_version: *baselibs_version
-          bcs_version: *bcs_version
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
           gcm_ocean_type: MOM6
           change_layout: false
 
@@ -75,7 +76,7 @@ workflows:
           filters:
             tags:
               only: /^v.*$/
-          name: publish-intel-docker-image
+          name: publish-ifort-docker-image
           context:
             - docker-hub-creds
             - ghcr-creds
@@ -85,11 +86,30 @@ workflows:
           container_name: geosgcm
           mpi_name: intelmpi
           mpi_version: "2021.13"
-          compiler_name: intel
-          compiler_version: "2024.2"
+          compiler_name: ifort
+          compiler_version: "2021.13"
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge
+      #- ci/publish_docker:
+          #filters:
+            #tags:
+              #only: /^v.*$/
+          #name: publish-ifx-docker-image
+          #context:
+            #- docker-hub-creds
+            #- ghcr-creds
+          #os_version: *os_version
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+          #container_name: geosgcm
+          #mpi_name: intelmpi
+          #mpi_version: "2021.13"
+          #compiler_name: ifx
+          #compiler_version: "2024.2"
+          #image_name: geos-env-bcs
+          #tag_build_arg_name: *tag_build_arg_name
+          #resource_class: xlarge
       - ci/publish_docker:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v8.5.0
+baselibs_version: &baselibs_version v8.6.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
@@ -65,7 +65,6 @@ workflows:
           baselibs_version: *baselibs_version
           bcs_version: *bcs_version
           gcm_ocean_type: MOM6
-          landbcs_type: NL3
           change_layout: false
 
   build-and-publish-docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
 orbs:
-  ci: geos-esm/circleci-tools@dev:9428a6bb28aa2f1623927873a863dcd381d55bd0
+  ci: geos-esm/circleci-tools@dev:f0c2c8ef70b5b840bbd8e08f6fabaa9f7bb4d5d4
   #ci: geos-esm/circleci-tools@5
 
 workflows:
@@ -66,6 +66,7 @@ workflows:
           baselibs_version: *baselibs_version
           bcs_version: *bcs_version
           gcm_ocean_type: MOM6
+          landbcs_type: NL3
           change_layout: false
 
   build-and-publish-docker:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v8.5.0-intelmpi_2021.13-intel_2024.2
+      image: gmao/ubuntu20-geos-env:v8.5.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.6.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.6.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.3.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.3.1)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.4.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.6.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.6.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.3.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.3.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.3.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.3.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.5.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.5.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.6.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.6.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.3.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.3.0)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.5.0
+  tag: v4.6.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.3.0
+  tag: v5.3.1
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.3.1
+  tag: v5.4.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates v12 to ESMA_cmake v4.6.0. This has preliminary support for Jemalloc and LLVM Flang.

It also updates to ESMA_env v5.4.1 which has updates for NAS as well as moving the default build processor for `parallel_build.csh` to Milan at NCCS and Rome at NAS.