### PR TITLE
Update to MAPL 2.49.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.48.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.48.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.49.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.49.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.48.0
+  tag: v2.49.1
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates the GCM to use MAPL 2.49.1.

The changes are actually pretty minor for how we run GEOS. MAPL 2.49.0 added zstandard compression support, but only Spack builds of MAPL/GEOS can utilize that at present.

MAPL 2.49.1 has a bug fix for an issue our UFS colleagues found, but as far as I know, we (GMAO) have never hit it.