### PR TITLE
Add ability to use MAPL as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.17)
+cmake_minimum_required (VERSION 3.23)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 
@@ -90,6 +90,11 @@ if (NOT Baselibs_FOUND)
   #   add_library(fms_r8 ALIAS FMS::fms_r8)       #
   # endif ()                                      #
   #################################################
+
+  find_package(MAPL 2.49 QUIET)
+  if (MAPL_FOUND)
+    message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
+  endif ()
 
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,17 +80,6 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  # Using FMS from spack requires updates to fvdycore due to interface changes
-  # in FMS 2022. This is commented for now until this transition can occur.
-  #################################################
-  # find_package(FMS QUIET COMPONENTS R4 R8)      #
-  # if (FMS_FOUND)                                #
-  #   # We need aliases due to historical reasons #
-  #   add_library(fms_r4 ALIAS FMS::fms_r4)       #
-  #   add_library(fms_r8 ALIAS FMS::fms_r8)       #
-  # endif ()                                      #
-  #################################################
-
   find_package(MAPL 2.49 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.51.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.51.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.52.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.52.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.29.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.29.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.12.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.12.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.51.0
+  tag: v3.52.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -39,6 +39,8 @@ GEOS_Util:
   tag: v2.1.2
   develop: main
 
+# When updating the MAPL version, also update the MAPL version in the
+# CMakeLists.txt file for non-Baselibs builds
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,8 +1,14 @@
 esma_add_subdirectories (
-  MAPL
   GMAO_Shared
   NCEP_Shared
   )
+
+if (NOT MAPL_FOUND)
+  message (STATUS "External MAPL library not found. Building MAPL from source.")
+  esma_add_subdirectory (MAPL)
+else ()
+  message (STATUS "MAPL library found. Using MAPL from ${MAPL_BASE_DIR}")
+endif ()
 
 if (NOT FMS_FOUND)
   message (STATUS "FMS library not found. Building FMS from source.")


### PR DESCRIPTION
This PR allows Spack to build GEOS using MAPL as an external dependency rather than internal.