### PR TITLE
v11: Update to MAPL 2.50.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.49 QUIET)
+  find_package(MAPL 2.50 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.50.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.50.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.50.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.50.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                        |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [sdr_v2.2.1.2](https://github.com/GEOS-ESM/GOCART/releases/tag/sdr_v2.2.1.2)                        |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.2.3](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.2.3)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.49.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.49.1)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.50.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.50.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
 | [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -42,7 +42,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.49.1
+  tag: v2.50.0
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -44,7 +44,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.50.0
+  tag: v2.50.1
   develop: develop
 
 FMS:


### PR DESCRIPTION
MAPL 2.50.0 has a bugfix when using point source emissions with stretched grids. All testing shows it zero-diff to MAPL 2.49

MAPL 2.50.1 has a bugfix that was causing issues with GNU + Debug and ExtData2G