### PR TITLE
v12: Update to Baselibs 8.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,9 @@ workflows:
           bcs_version: *bcs_version
           container_name: geosgcm
           mpi_name: openmpi
-          mpi_version: 5.0.2
+          mpi_version: 5.0.5
           compiler_name: gcc
-          compiler_version: 13.2.0
+          compiler_version: 14.2.0
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v8.6.0
+baselibs_version: &baselibs_version v8.7.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort, gfortran]
+              compiler: [gfortran, ifort, ifx]
           baselibs_version: *baselibs_version
           repo: GEOSgcm
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
@@ -44,7 +44,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [gfortran, ifort, ifx]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
@@ -58,7 +58,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort]
+              compiler: [ifort, ifx]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
@@ -90,25 +90,25 @@ workflows:
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge
-      #- ci/publish_docker:
-          #filters:
-            #tags:
-              #only: /^v.*$/
-          #name: publish-ifx-docker-image
-          #context:
-            #- docker-hub-creds
-            #- ghcr-creds
-          #os_version: *os_version
-          #baselibs_version: *baselibs_version
-          #bcs_version: *bcs_version
-          #container_name: geosgcm
-          #mpi_name: intelmpi
-          #mpi_version: "2021.13"
-          #compiler_name: ifx
-          #compiler_version: "2024.2"
-          #image_name: geos-env-bcs
-          #tag_build_arg_name: *tag_build_arg_name
-          #resource_class: xlarge
+      - ci/publish_docker:
+          filters:
+            tags:
+              only: /^v.*$/
+          name: publish-ifx-docker-image
+          context:
+            - docker-hub-creds
+            - ghcr-creds
+          os_version: *os_version
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+          container_name: geosgcm
+          mpi_name: intelmpi
+          mpi_version: "2021.14"
+          compiler_name: ifx
+          compiler_version: "2025.0"
+          image_name: geos-env-bcs
+          tag_build_arg_name: *tag_build_arg_name
+          resource_class: xlarge
       - ci/publish_docker:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,13 +52,16 @@ workflows:
           bcs_version: *bcs_version
 
       # Run Coupled GCM (1 hour, no ExtData)
+      # NOTE: Both gfortran and ifx seem to have
+      # issues with the Debug build of MOM6. For
+      # now, we only test on ifort
       - ci/run_gcm:
           name: run-coupled-GCM-on-<< matrix.compiler >>
           context:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort, ifx]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v8.5.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
+      image: gmao/ubuntu20-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.23)
+cmake_minimum_required (VERSION 3.24)
 cmake_policy (SET CMP0053 NEW)
 cmake_policy (SET CMP0054 NEW)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.7.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.7.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.9.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.9.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.10.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.10.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.7.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.7.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.4.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.4.1)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.0)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.7.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.7.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.9.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.9.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.5.0
+  tag: v5.5.1
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.7.0
+  tag: v4.9.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.4.1
+  tag: v5.5.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.9.0
+  tag: v4.10.0
   develop: develop
 
 ecbuild:

--- a/parallel_build.csh
+++ b/parallel_build.csh
@@ -35,6 +35,7 @@ if (-d ${ESMADIR}/@env || -d ${ESMADIR}/env@ || -d ${ESMADIR}/env) then
       echo "Checking out development branches of GEOSgcm_GridComp, GEOSgcm_App, GMAO_Shared, and GEOS_Util"
       mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util
    endif
+   mepo status
 else
    if ($?PBS_JOBID || $?SLURM_JOBID) then
       echo " mepo clone must be run!"
@@ -42,13 +43,13 @@ else
       echo " Please run from a head node"
       exit 1
    else
-      echo "Running mepo initialization"
-      mepo init
+      echo "Running mepo clone"
       mepo clone
       if ( "$DEVELOP" == "TRUE" ) then
          echo "Checking out development branches of GEOSgcm_GridComp, GEOSgcm_App, GMAO_Shared, and GEOS_Util"
          mepo develop GEOSgcm_GridComp GEOSgcm_App GMAO_Shared GEOS_Util
       endif
+      mepo status
    endif
 endif
 


### PR DESCRIPTION
This PR update GEOSgcm v12 to use ESMA_env v5.5.1. This has an update to Baselibs 8.7.0 which has ESMF 8.7.0. The main benefit to this is lower memory cost at very-high core count (thanks to @tclune and @atrayano for finding this!).

We also move to ESMA_cmake v4.9.0 which adds support for Python 3.12 as well as code to run `mepo status` at CMake time and capture that output for experiments.

All testing shows it zero-diff to v5.4.1

NOTE: 5.5.1 re-sets the executable bit on g5_modules. Not sure why it was removed.