### PR TITLE
v11: Update CI to use GCC 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu20
-baselibs_version: &baselibs_version v7.25.0
+baselibs_version: &baselibs_version v7.27.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 
@@ -103,9 +103,9 @@ workflows:
           bcs_version: *bcs_version
           container_name: geosgcm
           mpi_name: openmpi
-          mpi_version: 5.0.2
+          mpi_version: 5.0.5
           compiler_name: gcc
-          compiler_version: 13.2.0
+          compiler_version: 14.2.0
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v7.25.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu20-geos-env:v7.27.0-intelmpi_2021.13-ifort_2021.13
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests


### PR DESCRIPTION
This PR updates the CI to use GCC 14 for its GNU testing. This matches what we run in nightly tests.