### PR TITLE
v12: Move to use Ubuntu 24 in CI and Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: ""
 
 # Anchors to prevent forgetting to update a version
-os_version: &os_version ubuntu20
+os_version: &os_version ubuntu24
 baselibs_version: &baselibs_version v8.7.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
+      image: gmao/ubuntu24-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests


### PR DESCRIPTION
This PR updates v12 CI to use Ubuntu 24 in CI and Docker.