### PR TITLE
v12: Update to ESMA_cmake v4.12.0, ESMA_env 5.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
     default: ""
 
 # Anchors to prevent forgetting to update a version
-os_version: &os_version ubuntu20
+os_version: &os_version ubuntu24
 baselibs_version: &baselibs_version v8.7.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.7.0
+baselibs_version: &baselibs_version v8.9.0
 bcs_version: &bcs_version v12.0.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu20-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
+      image: gmao/ubuntu24-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-latest
     container:
-      image: gmao/ubuntu24-geos-env:v8.7.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
+      image: gmao/ubuntu24-geos-env:v8.9.0-intelmpi_2021.13-ifort_2021.13-bcs_v12.0.0
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ if (NOT Baselibs_FOUND)
 
   find_package(FMS REQUIRED COMPONENTS R4 R8)
 
+  # These aliases should be removed once the CMake in subrepos is fixed
+  add_library(fms_r4 ALIAS FMS::fms_r4)
+  add_library(fms_r8 ALIAS FMS::fms_r8)
+
   # At the moment, there is no way to know if FMS was built with YAML
   # so we need to rely on the user to set this option.
   option(FMS_BUILT_WITH_YAML "FMS was built with YAML" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,6 @@ if (NOT Baselibs_FOUND)
 
   find_package(FMS REQUIRED COMPONENTS R4 R8)
 
-  # These aliases should be removed once the CMake in subrepos is fixed
-  add_library(fms_r4 ALIAS FMS::fms_r4)
-  add_library(fms_r8 ALIAS FMS::fms_r8)
-
   # At the moment, there is no way to know if FMS was built with YAML
   # so we need to rely on the user to set this option.
   option(FMS_BUILT_WITH_YAML "FMS was built with YAML" OFF)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.11.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.10.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.10.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.11.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.11.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.5.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.5.1)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.6.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.6.0)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.11.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.12.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |

--- a/README.md
+++ b/README.md
@@ -255,23 +255,38 @@ source @env/g5_modules.sh
 ```
 
 ##### Create Build Directory
-We currently do not allow in-source builds of GEOSgcm. So we must make a directory:
-```
-mkdir build
-```
-The advantages of this is that you can build both a Debug and Release version with the same clone if desired.
 
 ##### Run CMake
-CMake generates the Makefiles needed to build the model.
+
+CMake generates the Makefiles needed to build the model. This command:
 ```
-cd build
-cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build -S . -DCMAKE_INSTALL_PREFIX=install
 ```
-This will install to a directory parallel to your `build` directory. If you prefer to install elsewhere change the path in:
+
+As is, this command assumes you are in the root of the GEOSgcm checkout and will create a `build/` directory in the root of the checkout and install into `install/ parallel to the `build/` directory.
+
+This command has three options:
+
+1. `-B` specifies the build directory.
+2. `-S` specifies the source directory (root of the checkout).
+3. `-DCMAKE_INSTALL_PREFIX` specifies the installation directory.
+
+If you prefer to install elsewhere change the path in:
+
 ```
--DCMAKE_INSTALL_PREFIX=<path>
+-DCMAKE_INSTALL_PREFIX=/path/to/install
 ```
 and CMake will install there.
+
+If you prefer your build somewhere else, you can specify that with:
+```
+-B /path/to/build
+```
+
+Finally, if your source is in a different directory than the current one, you can specify that with:
+```
+-S /path/to/source
+```
 
 ###### Create and install source tarfile
 
@@ -283,7 +298,7 @@ to your CMake command.
 
 ##### Build and Install with Make
 ```
-make -jN install
+cmake --build build -j N
 ```
 where `N` is the number of parallel processes. On discover head nodes, this should only be as high as 2 due to limits on the head nodes. On a compute node, you can set `N` has high as you like, though 8-12 is about the limit of parallelism in our model's make system.
 
@@ -291,7 +306,7 @@ where `N` is the number of parallel processes. On discover head nodes, this shou
 
 Once the model has built successfully, you will have an `install/` directory in your checkout. To run `gcm_setup` go to the `install/bin/` directory and run it there:
 ```
-cd install/bin
+cd /path/to/install/bin
 ./gcm_setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.11.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.11.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.6.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.6.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.0)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.11.0
+  tag: v4.12.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.7.0
+  tag: v5.7.1
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -160,7 +160,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: GCMv12-rc10
+  tag: GCMv12-rc10b
   develop: feature/sdrabenh/gcm_v12
 
 RRTMGP:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.6.0
+  tag: v5.7.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.5.1
+  tag: v5.6.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.10.0
+  tag: v4.11.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates ESMA_cmake to use the `LOCATION` strategy for finding Python. This is needed as NAS (at least) has a very recent, but empty (no f2py) Python stack in the default path. Using `LOCATION` should limit it to the Python we want (e.g., via GEOSpyD module). 

We also update ESMA_cmake to change the Intel Fortran flags to new ones by @wmputman. 

_**NOTE: This is NON-ZERO-DIFF!**_

We also update to ESMA_env v5.7.0 which moves to use MPT 2.30 Baselibs at NAS and to Baselibs 8.9.0 (which has ESMF 8.8.0)

I've also updated CI to use Ubuntu 24 and modernized the CMake calls in `README.md`