### PR TITLE
Move MAM, MATRIX, CARMA, GAAS, ACHEM to separate repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | Repository                                                                     | Version                                                                                               |
 | ----------                                                                     | -------                                                                                               |
 | [ACHEM](https://github.com/GEOS-ESM/ACHEM)                                     | [v1.0.0](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.0.0)                                       |
-| [CARMA](https://github.com/GEOS-ESM/CARMA)                                     | [v1.0.0](https://github.com/GEOS-ESM/CARMA/releases/tag/v1.0.0)                                       |
+| [CARMA](https://github.com/GEOS-ESM/CARMA)                                     | [v1.1.0](https://github.com/GEOS-ESM/CARMA/releases/tag/v1.1.0)                                       |
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                         |

--- a/README.md
+++ b/README.md
@@ -2,50 +2,54 @@
 
 ## CI Status
 
-| CI Provider | Status |
-| ----------- | ------ |
+| CI Provider | Status                                                                                                          |
+| ----------- | ------                                                                                                          |
 | CircleCI    | [![CircleCI](https://circleci.com/gh/GEOS-ESM/GEOSgcm.svg?style=svg)](https://circleci.com/gh/GEOS-ESM/GEOSgcm) |
-| AWS CodeBuild | ![CodeBuild](https://codebuild.us-east-1.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiZitEZE1kODFtUUhuZU5tN1pDbHZvbDlEQUEwNWR0a2JCM1F1MmlTaWZYV1JxNWIxMjZDSThOUi9mUDJKSVBuaEVRa1FxV2FncitOcExyemNaWFFIbjVrPSIsIml2UGFyYW1ldGVyU3BlYyI6IlBudmE3N1A0MTNNR3ZhNVoiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main) |
-| GitHub | ![GitHub](https://github.com/GEOS-ESM/GEOSgcm/workflows/Build%20Tests/badge.svg) |
+| GitHub      | ![GitHub](https://github.com/GEOS-ESM/GEOSgcm/workflows/Build%20Tests/badge.svg)                                |
 
 ## Current State of GEOSgcm Subrepos
 
-| Repository                                                                     | Version                                                                                             |
-| ----------                                                                     | -------                                                                                             |
-| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                          |
-| [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
-| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.56.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.56.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.34.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.34.0)                                |
+| Repository                                                                     | Version                                                                                               |
+| ----------                                                                     | -------                                                                                               |
+| [ACHEM](https://github.com/GEOS-ESM/ACHEM)                                     | [v1.0.0](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.0.0)                                       |
+| [CARMA](https://github.com/GEOS-ESM/CARMA)                                     | [v1.0.0](https://github.com/GEOS-ESM/CARMA/releases/tag/v1.0.0)                                       |
+| [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
+| [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
+| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                         |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.56.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.56.0)                                |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v4.34.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.34.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.13.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.13.0)                    |
-| [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.3.0)                        |
-| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.3)                                 |
-| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.15.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.15.0)                       |
-| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.7](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.7)                               |
-| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.4](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.4)                          |
+| [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
+| [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.3.0)                          |
+| [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.3](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.3)                                   |
+| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.15.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.15.0)                         |
+| [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.7](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.7)                                 |
+| [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.4](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.4)                            |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.10.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.10.0)                    |
-| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.9.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.9.1)       |
-| [gigatraj](https://github.com/GEOS-ESM/gigatraj)                               | [geos/v1.0.0](https://github.com/GEOS-ESM/gigatraj/releases/tag/geos%2Fv1.0.0)       |
-| [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.3.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.3.0)                                       |
-| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.9](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.9)                               |
-| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.3.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.3.0)                            |
-| [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                         |
-| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.52.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.52.0)                                    |
-| [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
-| [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                        |
-| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
-| [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
-| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.7+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)          |
-| [SIS2](https://github.com/GEOS-ESM/SIS2)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/SIS2/releases/tag/geos%2Fv0.0.1)                          |
-| [StratChem](https://github.com/GEOS-ESM/StratChem)                             | [v1.0.0](https://github.com/GEOS-ESM/StratChem/releases/tag/v1.0.0)                                 |
-| [TR](https://github.com/GEOS-ESM/TR)                                           | [v1.2.0](https://github.com/GEOS-ESM/TR/releases/tag/v1.2.0)                                        |
-| [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.3.0](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.3.0)                                   |
-| [WW3](https://github.com/GEOS-ESM/WW3)                                         | [v6.07.1-geos-r2](https://github.com/GEOS-ESM/WW3/releases/tag/v6.07.1-geos-r2)                     |
-| [umwm](https://github.com/GEOS-ESM/umwm)                                       | [v2.0.0-geos-r1](https://github.com/GEOS-ESM/umwm/releases/tag/v2.0.0-geos-r1)                      |
+| [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.9.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.9.1)         |
+| [gigatraj](https://github.com/GEOS-ESM/gigatraj)                               | [geos/v1.0.0](https://github.com/GEOS-ESM/gigatraj/releases/tag/geos%2Fv1.0.0)                        |
+| [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.3.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.3.0)                                         |
+| [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v1.9.9](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.9)                                 |
+| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.3.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.3.0)                                      |
+| [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
+| [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
+| [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.0.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.0.0)                                         |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.52.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.52.0)                                      |
+| [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
+| [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
+| [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                          |
+| [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                                 |
+| [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                   |
+| [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.7+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)            |
+| [SIS2](https://github.com/GEOS-ESM/SIS2)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/SIS2/releases/tag/geos%2Fv0.0.1)                            |
+| [StratChem](https://github.com/GEOS-ESM/StratChem)                             | [v1.0.0](https://github.com/GEOS-ESM/StratChem/releases/tag/v1.0.0)                                   |
+| [TR](https://github.com/GEOS-ESM/TR)                                           | [v1.2.0](https://github.com/GEOS-ESM/TR/releases/tag/v1.2.0)                                          |
+| [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.3.0](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.3.0)                                     |
+| [WW3](https://github.com/GEOS-ESM/WW3)                                         | [v6.07.1-geos-r2](https://github.com/GEOS-ESM/WW3/releases/tag/v6.07.1-geos-r2)                       |
+| [umwm](https://github.com/GEOS-ESM/umwm)                                       | [v2.0.0-geos-r1](https://github.com/GEOS-ESM/umwm/releases/tag/v2.0.0-geos-r1)                        |
 
 ## How to build GEOS GCM
 

--- a/components.yaml
+++ b/components.yaml
@@ -129,15 +129,13 @@ StratChem:
 MAM:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@MAM
   remote: ../MAM.git
-  #tag: v1.0.0
-  branch: main
+  tag: v1.0.0
   develop: main
 
 MATRIX:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@MATRIX
   remote: ../MATRIX.git
-  #tag: v1.0.0
-  branch: main
+  tag: v1.0.0
   develop: main
 
 CARMA:
@@ -152,15 +150,13 @@ CARMA:
 GAAS:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GAAS
   remote: ../GAAS.git
-  #tag: v1.0.0
-  branch: main
+  tag: v1.0.0
   develop: develop
 
 ACHEM:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@ACHEM
   remote: ../ACHEM.git
-  #tag: v1.0.0
-  branch: main
+  tag: v1.0.0
   develop: develop
 
 GEOS_OceanGridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -144,7 +144,9 @@ CARMA:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@CARMA
   remote: ../CARMA.git
   #tag: v1.0.0
-  branch: main
+  # NOTE: Must use develop due to https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/290 and since
+  # the chem branch is off develop
+  branch: develop
   develop: develop
 
 GAAS:

--- a/components.yaml
+++ b/components.yaml
@@ -234,7 +234,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v2.3.7
+  branch: feature/mathomp4/split-chem-2025Jan23
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -141,10 +141,7 @@ MATRIX:
 CARMA:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@CARMA
   remote: ../CARMA.git
-  #tag: v1.0.0
-  # NOTE: Must use develop due to https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/290 and since
-  # the chem branch is off develop
-  branch: develop
+  tag: v1.1.0
   develop: develop
 
 GAAS:

--- a/components.yaml
+++ b/components.yaml
@@ -81,7 +81,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.15.0
+  branch: feature/mathomp4/split-chem-2025Jan23
   develop: develop
 
 HEMCO:
@@ -124,6 +124,41 @@ StratChem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@StratChem
   remote: ../StratChem.git
   tag: v1.0.0
+  develop: develop
+
+MAM:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@MAM
+  remote: ../MAM.git
+  #tag: v1.0.0
+  branch: main
+  develop: main
+
+MATRIX:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@MATRIX
+  remote: ../MATRIX.git
+  #tag: v1.0.0
+  branch: main
+  develop: main
+
+CARMA:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@CARMA
+  remote: ../CARMA.git
+  #tag: v1.0.0
+  branch: main
+  develop: develop
+
+GAAS:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GAAS
+  remote: ../GAAS.git
+  #tag: v1.0.0
+  branch: main
+  develop: develop
+
+ACHEM:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@ACHEM
+  remote: ../ACHEM.git
+  #tag: v1.0.0
+  branch: main
   develop: develop
 
 GEOS_OceanGridComp:


### PR DESCRIPTION
Supersedes #571 

---

This PR moves MAM, MATRIX, CARMA, GAAS, and GEOSachem to separate repos. There will be a few steps to get this in:

- [x] Create MAM Repo → https://github.com/GEOS-ESM/MAM
- [x] Create MATRIX Repo → https://github.com/GEOS-ESM/MATRIX
- [x] Create CARMA Repo → https://github.com/GEOS-ESM/CARMA
- [x] Create GAAS Repo → https://github.com/GEOS-ESM/GAAS
- [x] Create ACHEM Repo → https://github.com/GEOS-ESM/ACHEM
- [ ] Remove directories from GEOSchem_GridComp → https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/291
- [ ] Update GEOSgcm_App → https://github.com/GEOS-ESM/GEOSgcm_App/pull/686
- [ ] Test this in the naive way (usual AMIP)
- [ ] Release GEOSchem_GridComp v1.16.0
- [x] Release MAM v1.0.0
- [x] Release MATRIX v1.0.0
- [x] Release CARMA v1.0.0 and v1.1.0
- [x] Release GAAS v1.0.0
- [x] Release ACHEM v1.0.0
- [ ] Update `components.yaml` here to point to tags not branches