### PR TITLE
v11: Update to MOM6 geos/v3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.52.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.52.0)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)              |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.3](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.3)                                        |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.4](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.4)                                        |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.7+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)          |

--- a/components.yaml
+++ b/components.yaml
@@ -141,7 +141,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v3.3
+  tag: geos/v3.4
   develop: main
   recurse_submodules: true
 


### PR DESCRIPTION
This PR has updates for moving to MOM6 geos/v3.4 which matches the mother repo as of 2025-Jan-13 following the merge of https://github.com/mom-ocean/MOM6/pull/1647

Tests show this is zero-diff for GEOSgcm.

Keeping draft until v-tag releases of GEOS_OceanGridComp are made.