### PR TITLE
v11: Update to GEOSradiation_GridComp v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.15.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.15.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.8](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.8)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.7.0](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.7.0)                          |
-| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.10.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.10.0)                    |
+| [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.11.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.11.0)                    |
 | [GFDL_atmos_cubed_sphere](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere) | [geos/v2.9.1](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.9.1)       |
 | [gigatraj](https://github.com/GEOS-ESM/gigatraj)                               | [geos/v1.0.0](https://github.com/GEOS-ESM/gigatraj/releases/tag/geos%2Fv1.0.0)       |
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.3.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.3.0)                                       |

--- a/components.yaml
+++ b/components.yaml
@@ -172,7 +172,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: v1.10.0
+  tag: v1.11.0
   develop: develop
 
 RRTMGP:


### PR DESCRIPTION
This PR updates GEOSradiation_GridComp to v1.11.0. This release has fixes for the `ifx` compiler in the Irrad GC. v1.10.0 had the fixes in Solar, but it turned out that wasn't enough.

All testing with GEOS shows it to be zero-diff.

NOTE: #884 updates to Radiation v1.12.0 for RRG support. So if that goes in before this, this can be closed.