### PR TITLE
v12: Update to GEOS_OceanGridComp v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.4.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.4.0)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.4.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.4.1)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.2)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -117,7 +117,7 @@ StratChem:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.4.0
+  tag: v3.4.1
   develop: develop
 
 mom:


### PR DESCRIPTION
This PR updates GEOSgcm v12 to GEOS_OceanGridComp v3.4.1. 

This has a bugfix from @zhaobin74 for an [issue with `FRZMLT`](https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/85). 

This is zero-diff for data-ocean runs, but non-zero-diff for MOM6 runs.