### PR TITLE
v11: Update to GEOS_OceanGridComp v2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.13.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.13.0)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.4.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.4.0)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.4.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.4.1)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.6](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.6)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.15.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.15.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.8](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.8)                               |

--- a/components.yaml
+++ b/components.yaml
@@ -129,7 +129,7 @@ StratChem:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v2.4.0
+  tag: v2.4.1
   develop: release/v2
 
 mom:


### PR DESCRIPTION
This PR updates GEOSgcm v11 to GEOS_OceanGridComp v2.4.1. 

This has a bugfix from @zhaobin74 for an [issue with `FRZMLT`](https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/85). 

This is zero-diff for data-ocean runs, but non-zero-diff for MOM6 runs.