### PR TITLE
v11: Update mom6 develop to geos/main

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -178,7 +178,7 @@ mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
   tag: geos/v3.4
-  develop: main
+  develop: geos/main
   recurse_submodules: true
 
 mit:


### PR DESCRIPTION
Until now, GEOS has not done any major development on MOM6. Rather, we've used the `main` from the mom-ocean mother repo.

But, @mfmehari will soon have some (for now) GEOS-specific edits to MOM6 for his work. Thus, we have created a new `geos/main` branch in MOM6 so that our changes can live there. 

So in this PR, we move the mepo `develop:` for mom6 to `geos/main`. That way `mepo develop mom6` points to the right branch.