### PR TITLE
v12: Update to Ocean GC v3.5.0, mom6 geos/v3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.4.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.4.1)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.5.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.5.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.2)                                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |
@@ -34,7 +34,7 @@
 | [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.50.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.50.1)                                    |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                      |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+2.1.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B2.1.0)              |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.4](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.4)                                        |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.5](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.5)                                        |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.3.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.3.0)                               |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                 |
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.8+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.8%2B1.0.0)          |

--- a/components.yaml
+++ b/components.yaml
@@ -117,7 +117,7 @@ StratChem:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.4.1
+  tag: v3.5.0
   develop: develop
 
 mom:
@@ -129,7 +129,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v3.4
+  tag: geos/v3.5
   develop: main
   recurse_submodules: true
 

--- a/components.yaml
+++ b/components.yaml
@@ -130,7 +130,7 @@ mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
   tag: geos/v3.5
-  develop: main
+  develop: geos/main
   recurse_submodules: true
 
 mit:


### PR DESCRIPTION
This PR updates GEOSgcm v12 to GEOS_OceanGridComp to v2.5.0 and mom6 to geos/v3.5. These updates are from @mfmehari and have changes needed for NOBM work.

My testing shows it is zero-diff for both AMIP and MOM6 runs.

We also move the mepo `develop:` for mom6 to `geos/main`. That way `mepo develop mom6` points to the right branch (since we now have code outside of mom6 mainline).