### PR TITLE
Add HETP aerosol thermodynamic submodule used in GEOS-Chem

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -88,6 +88,12 @@ Cloud-J:
   branch: geos/latest_gcc 
   develop: geos/develop
 
+HETP:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/HETP/@HETP
+  remote: ../heterogeneous-vectorized-or-parallel.git
+  branch: geoschem/main
+  develop: geoschem/main
+
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git


### PR DESCRIPTION
This PR adds the [HETP submodule](https://github.com/geoschem/HETerogeneous-vectorized-or-Parallel) to components.yaml for use within the geos/latest_gcc branch. That branch includes GEOS-Chem 14.5 which requires HETP for aerosol thermodynamics.

HETP is short for heterogeneous-vectorized-or-parallel which is a fortran package that is an improved version of ISORROPIA. It was developed by Stefan Miller at Environment and Climate Change Canada. GEOS-Chem uses a fork of the [original repository](https://github.com/sjmiller204/HETerogeneous-vectorized-or-Parallel) within the GEOS-Chem github workspace pending its transfer from a Stefan's personal GitHub to one affiliated with Environment and Climate Change Canada.