### PR TITLE
Add geos_state_bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.2)                                 |
-| [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/v1.0.0)                      |
+| [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/geos/v1.0.0)                 |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.1)                          |

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                               |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.3.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.3.0)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.12.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.12.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                |
-| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                    |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.7.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.7.1)                                  |
+| [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.11.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.11.1)                  |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)           |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.3.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.3.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.2)                                 |
+| [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/v1.0.0)                      |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.14.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.14.0)                       |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.4](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.4)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.6.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.6.1)                          |

--- a/components.yaml
+++ b/components.yaml
@@ -54,6 +54,12 @@ GEOSgcm_GridComp:
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: feature/sdrabenh/gcm_v12
 
+geos_state_bias:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSmkiau_GridComp/pyMLINC/@geos_state_bias
+  remote: ../geos_state_bias.git
+  tag: geos/v1.0.0
+  develop : geos/develop
+
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git

--- a/components.yaml
+++ b/components.yaml
@@ -44,20 +44,20 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: GCMv12-rc11
+  tag: GCMv12-rc12
   develop: feature/sdrabenh/gcm_v12
 
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: GCMv12-rc11
+  tag: GCMv12-rc12
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: feature/sdrabenh/gcm_v12
 
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: GCMv12-rc11
+  tag: GCMv12-rc12
   develop: feature/sdrabenh/gcm_v12
 
 fvdycore:
@@ -160,7 +160,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: GCMv12-rc11
+  tag: GCMv12-rc12
   develop: feature/sdrabenh/gcm_v12
 
 RRTMGP:
@@ -185,7 +185,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: GCMv12-rc11
+  tag: GCMv12-rc12
   develop: feature/sdrabenh/gcm_v12
 
 UMD_Etc:


### PR DESCRIPTION
Added the mepo component [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias) to `components.yaml` of GEOSgcm.

This PR is contingent on https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1077 being accepted 