### PR TITLE
Add HETP to components.yaml

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -88,6 +88,11 @@ Cloud-J:
   branch: geos/latest_gcc 
   develop: geos/develop
 
+HETP:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/HETP/@HETP
+  remote: ../HETerogeneous-vectorized-or-Parallel.git
+  branch: origin/main
+
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git


### PR DESCRIPTION
GEOS-Chem versions 14.5+ use the HETP repository. This PR adds HETP to components.yaml. @mathomp4, should this be in the GEOSCHEMchem folder, if it is only used by GEOS-Chem?