### PR TITLE
Sparsing GEOSgcm_GridComp further

### DIFF
--- a/config/GEOSgcm_GridComp.sparse
+++ b/config/GEOSgcm_GridComp.sparse
@@ -1,10 +1,15 @@
 /*
+!/GEOSgigatraj_GridComp
+!/GEOSwgcm_GridComp
+
 !/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
 !/GEOSagcm_GridComp/GEOShs_GridComp
 !/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/ARIESg3_GridComp
 !/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycore_GridComp
 
+!/GEOSogcm_GridComp/GEOS_OradGridComp
+!/GEOSogcm_GridComp/GEOS_OradBioGridComp
+!/GEOSogcm_GridComp/GEOS_OceanBioGeoChemGridComp
+
 !/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug
-
-!/GEOSwgcm_GridComp
-
+!/GEOSogcm_GridComp/GEOSseaice_GridComp/GEOSMITDyna_GridComp


### PR DESCRIPTION
Removed GEOSgigatraj, GEOS_Orad, GEOS_OradBio, GEOS_OceanBioGeoChem, GEOSMITDyna. Unfortunately, cannot remove GEOSdataatm (needed by GEOSgcm) and GEOSCICE_Dyna (needed by GEOSdataseaicea)