### PR TITLE
v12: Update to ESMA_cmake v4.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.0.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.0.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.16.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.16.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.17.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.17.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.11.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.11.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.16.0
+  tag: v4.17.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR is a minor update to ESMA_cmake to enforce our allowed `CMAKE_BUILD_TYPE`