### PR TITLE
v12: Add Build Info, Update ESMA_env, ESMA_cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,25 +93,25 @@ workflows:
           image_name: geos-env-bcs
           tag_build_arg_name: *tag_build_arg_name
           resource_class: xlarge
-      - ci/publish_docker:
-          filters:
-            tags:
-              only: /^v.*$/
-          name: publish-ifx-docker-image
-          context:
-            - docker-hub-creds
-            - ghcr-creds
-          os_version: *os_version
-          baselibs_version: *baselibs_version
-          bcs_version: *bcs_version
-          container_name: geosgcm
-          mpi_name: intelmpi
-          mpi_version: "2021.14"
-          compiler_name: ifx
-          compiler_version: "2025.0"
-          image_name: geos-env-bcs
-          tag_build_arg_name: *tag_build_arg_name
-          resource_class: xlarge
+      #- ci/publish_docker:
+          #filters:
+            #tags:
+              #only: /^v.*$/
+          #name: publish-ifx-docker-image
+          #context:
+            #- docker-hub-creds
+            #- ghcr-creds
+          #os_version: *os_version
+          #baselibs_version: *baselibs_version
+          #bcs_version: *bcs_version
+          #container_name: geosgcm
+          #mpi_name: intelmpi
+          #mpi_version: "2021.14"
+          #compiler_name: ifx
+          #compiler_version: "2025.0"
+          #image_name: geos-env-bcs
+          #tag_build_arg_name: *tag_build_arg_name
+          #resource_class: xlarge
       - ci/publish_docker:
           filters:
             tags:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if (NOT Baselibs_FOUND)
     target_link_libraries(FMS::fms_r8 INTERFACE ${LIBYAML_LIBRARIES})
   endif ()
 
-  find_package(MAPL 2.55 QUIET)
+  find_package(MAPL 2.56 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | [CARMA](https://github.com/GEOS-ESM/CARMA)                                     | [v1.1.0](https://github.com/GEOS-ESM/CARMA/releases/tag/v1.1.0)                                       |
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
-| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.0.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.0.0)                         |
+| [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.18.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.18.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.12.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.12.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.18.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.18.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.18.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.18.1)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.12.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.12.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.0)                    |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.0.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.0.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.55.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.55.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.56.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.56.0)                                    |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.18.0
+  tag: v4.18.1
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -50,7 +50,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: GCMv12-rc13
+  tag: v2.56.0
   develop: feature/sdrabenh/gcm_v12
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -17,7 +17,7 @@ cmake:
 ecbuild:
   local: ./@cmake/@ecbuild
   remote: ../ecbuild.git
-  tag: geos/v2.0.0
+  tag: geos/v2.1.0
 
 NCEP_Shared:
   local: ./src/Shared/@NCEP_Shared

--- a/components.yaml
+++ b/components.yaml
@@ -239,7 +239,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: GCMv12-rc14
+  tag: GCMv12-rc15
   develop: feature/sdrabenh/gcm_v12
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -56,7 +56,7 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc14
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: feature/sdrabenh/gcm_v12
 
@@ -75,13 +75,13 @@ GigaTraj:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc14
   develop: feature/sdrabenh/gcm_v12
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc14
   develop: feature/sdrabenh/gcm_v12
 
 GEOSchem_GridComp:
@@ -214,7 +214,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc14
   develop: feature/sdrabenh/gcm_v12
 
 RRTMGP:
@@ -239,7 +239,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc14
   develop: feature/sdrabenh/gcm_v12
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -29,16 +29,14 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  #tag: GCMv12-rc8
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   sparse: ./config/GMAO_Shared.sparse
   develop: feature/sdrabenh/gcm_v12
 
 GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
-  #branch: feature/sdrabenh/gcm_v12
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 GMAO_perllib:
@@ -52,14 +50,13 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.55.0
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  #branch: feature/sdrabenh/gcm_v12
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: feature/sdrabenh/gcm_v12
 
@@ -78,19 +75,19 @@ GigaTraj:
 FVdycoreCubed_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp
   remote: ../FVdycoreCubed_GridComp.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 fvdycore:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/@FVdycoreCubed_GridComp/@fvdycore
   remote: ../GFDL_atmos_cubed_sphere.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 HEMCO:
@@ -108,7 +105,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 QuickChem:
@@ -168,7 +165,7 @@ GAAS:
 ACHEM:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@ACHEM
   remote: ../ACHEM.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 GEOS_OceanGridComp:
@@ -217,7 +214,7 @@ sis2:
 GEOSradiation_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSradiation_GridComp
   remote: ../GEOSradiation_GridComp.git
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 RRTMGP:
@@ -242,8 +239,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  #branch: feature/sdrabenh/gcm_v12
-  branch: feature/sdrabenh/gcm_v12
+  tag: GCMv12-rc13
   develop: feature/sdrabenh/gcm_v12
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: GCMv12-rc13
+  tag: GCMv12-rc15
   sparse: ./config/GMAO_Shared.sparse
   develop: feature/sdrabenh/gcm_v12
 
@@ -56,7 +56,7 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: GCMv12-rc14
+  tag: GCMv12-rc15
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: feature/sdrabenh/gcm_v12
 

--- a/components.yaml
+++ b/components.yaml
@@ -29,7 +29,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: GCMv12-rc15
+  tag: GCMv12-rc16
   sparse: ./config/GMAO_Shared.sparse
   develop: feature/sdrabenh/gcm_v12
 


### PR DESCRIPTION
This PR is from a conversation with myself and Nicko Acks of NCCS. Namely, it would be nice to have a file that determines build information of a GEOS build.

This PR requires some updates to ESMA_env and ESMA_cmake.

* [ESMA_env v5.12.0](https://github.com/GEOS-ESM/ESMA_env/tree/v5.12.0)
* [ESMA_cmake v4.18.0](https://github.com/GEOS-ESM/ESMA_cmake/tree/v4.18.0)

This is some example output:

```
== Build Configuration ==
Build Type: Debug

== System ==
System Name: Linux
System Version: 5.14.21-150400.24.100-default
Host System: Linux-5.14.21-150400.24.100-default
Processor Description: 128 core AMD EPYC 7713 64-Core Processor

== CMake ==
CMake Version Used for Build: 4.0.1
CMake Required Version: 3.24

== Git ==
Git Version: 2.49.0

== Modules ==
fast-mkl-amd/1.0;python/GEOSpyD/24.11.3-0/3.12;ImageMagick/7.1.1-15;other/tree/2.1.0;other/ninja/1.12.0;GEOSenv;comp/gcc/12.3.0;comp/intel/2024.2.0;mpi/impi/2021.13;git/2.49.0;cmake/4.0.1;git-lfs/3.4.0;other/mepo/2.3.2;other/tig/2.5.8;other/gh;other/parallel/20250222;other/vim/9.1.1313

== Basedir ==
BASEDIR: /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15

== Compilers ==
C Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icx (ID: IntelLLVM 2024.2.0)
C++ Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/icpx (ID: IntelLLVM 2024.2.0)
Fortran Compiler: /usr/local/intel/oneapi/2024/compiler/2024.2/bin/ifort (ID: Intel 2021.0.0.20240602)

== MPI ==
MPI C Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiicc
MPI C++ Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiicpc
MPI Fortran Compiler: /usr/local/intel/oneapi/2024/mpi/2021.13/bin/mpiifort
MPI Version:
MPI Libraries: /gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpicxx.so;/gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpifort.so;/gpfsm/dulocal15/sles15/intel/oneapi/2024/mpi/2021.13/lib/libmpi.so;/usr/lib64/libdl.so;/usr/lib64/librt.so;/usr/lib64/libpthread.so
MPI Stack: intelmpi
MPI Stack Version: 2021.13

== BLAS ==
BLAS_LIBRARIES: /usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_intel_lp64.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_sequential.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_core.so;-pthread;-lm;-ldl

== LAPACK ==
LAPACK_LIBRARIES: /usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_intel_lp64.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_sequential.so;/usr/local/intel/oneapi/2024/mkl/2024.2/lib/libmkl_core.so;-pthread;-lm;-ldl;-pthread;-lm;-ldl

== ESMF ==
ESMF_VERSION: 8.8.0
ESMFMKFILE: /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15/Linux/lib/esmf.mk
```