### PR TITLE
v12: Update to MAPL 2.60.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if (NOT Baselibs_FOUND)
     target_link_libraries(FMS::fms_r8 INTERFACE ${LIBYAML_LIBRARIES})
   endif ()
 
-  find_package(MAPL 2.59 QUIET)
+  find_package(MAPL 2.60 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.59.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.59.0)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.60.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.60.0)                                    |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -50,7 +50,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.59.0
+  tag: v2.60.0
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This PR updates GEOSgcm v12 to MAPL 2.60.0. Note that this is labeled as both zero-diff and non-zero-diff. The reason is that with the update, the `ss_internal_checkpoint` will change as a field `DEEP_LAKES_MASK` will not be in the checkpoint. This is actually the correct behavior as MAPL 2.60 fixes a bug in the MAPL Automatic Code Generator (ACG) used by GOCART to create the Fortran code for the various imports/exports/internals.

This is the non-zero-diff part, but the model as a whole is zero-diff. The state and history output will be zero-diff. `DEEP_LAKES_MASK` is a `MAPL_RestartSkip` field in the SS Internal state and is recalculated at each time step.

For more information, see the release notes for [MAPL 2.60.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.60.0)