### PR TITLE
v12: Update to ESMA_cmake v4.25.0, ESMA_env v5.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.23.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.23.1)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.24.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.24.0)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.14.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.14.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.1)                    |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.23.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.23.0)                              |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.23.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.23.1)                              |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.14.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.14.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.1)                    |

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.24.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.24.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.14.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.14.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.25.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.25.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.15.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.15.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.1)                    |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v2.1.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv2.1.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.22.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.22.0)                              |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.13.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.13.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.23.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.23.0)                              |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.14.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.14.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.14.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.14.1)                    |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.13.0
+  tag: v5.14.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.22.0
+  tag: v4.23.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.23.1
+  tag: v4.24.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.14.0
+  tag: v5.15.0
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.24.0
+  tag: v4.25.0
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.23.0
+  tag: v4.23.1
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates v12 to ESMA_cmake v4.25.0 (Support for ifx 2025.2; bug fix for `FPE1` use in v12; remove support for Python 2; updated `ifort` flags, add new `VectTrap` build type) and to ESMA_env v5.15.0 (Baselibs 8.19.0 → ESMF v9.0.0b03; add `-vecttrap` option to `build.csh`).

Note the changes in ESMA_cmake for `ifort` flags were tested with other non-zero-diff changes in v12. But it seems likely that just the flag changes alone could cause non-zero-diff. So we label as such.