### PR TITLE
v11: Update to MAPL 2.65.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (NOT Baselibs_FOUND)
   # Another issue with historical reasons, old/wrong zlib target used in GEOS
   add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
 
-  find_package(MAPL 2.64 QUIET)
+  find_package(MAPL 2.65 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                         |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                       |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.0.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.0.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.46.2](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.46.2)                                    |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.65.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.65.0)                                    |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -50,7 +50,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.46.2
+  tag: v2.65.0
   develop: develop
 
 FMS:


### PR DESCRIPTION
This PR updates to MAPL 2.64.2. This has a bugfix for a bug discovered by @rtodling in ADAS testing where GAAS AOD reads were not being done correctly.

This is zero-diff unless you were triggering the GAAS bug.

---

ETA: I've pushed a change to MAPL 2.65.0. This has a bugfixes from @atrayano for a memory leak found by @mmanyin as well as a history bug found by @michellefrazer and @sdrabenh .

Note the memory leak fix is a two-parter which will need an upcoming change in GEOSgcm_GridComp. But the MAPL update is safe to take without it.