### PR TITLE
v12: Update to MAPL 2.64.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.64.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.64.1)                                      |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.64.2](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.64.2)                                      |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -50,7 +50,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.64.1
+  tag: v2.64.2
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This PR updates to MAPL 2.64.2. This has a bugfix for a bug discovered by @rtodling in ADAS testing where GAAS AOD reads were not being done correctly.

This is zero-diff unless you were triggering the GAAS bug.