### PR TITLE
v11: Update to ESMA_cmake v3.72.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                         |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.72.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.72.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.72.1](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.72.1)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.17.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.17.0)                                |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.10](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.10) |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.16.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.16.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.72.0
+  tag: v3.72.1
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates to ESMA_cmake v3.72.1 which has updates for f2py on macOS using Spack and a Ninja fix.

Zero-diff.