### PR TITLE
v12: Update to GEOS_OceanGridComp v3.9.0, mom6 geos/v3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
 | [GenCast-GEOS_FP](https://github.com/GEOS-ESM/GenCast_GEOS-FP)                 | [geos/v0.3.1](https://github.com/GEOS-ESM/GenCast_GEOS-FP/releases/tag/geos%2Fv0.3.1)                 |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.8.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.8.0)                          |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.9.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.9.0)                          |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.11](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.11)                                 |
 | [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/geos/v1.0.0)                   |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.16.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.16.0)                         |
@@ -43,7 +43,7 @@
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.7](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.7)                                          |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.8](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.8)                                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.4.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.4.0)                                 |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                   |
 | [RRG](https://github.com/GEOS-ESM/RRG)                                         | [v1.1.0](https://github.com/GEOS-ESM/RRG/releases/tag/v1.1.0)                                         |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
 | [GenCast-GEOS_FP](https://github.com/GEOS-ESM/GenCast_GEOS-FP)                 | [geos/v0.3.1](https://github.com/GEOS-ESM/GenCast_GEOS-FP/releases/tag/geos%2Fv0.3.1)                 |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.7.1](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.7.1)                          |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.8.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.8.0)                          |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.11](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.11)                                 |
 | [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/geos/v1.0.0)                   |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.16.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.16.0)                         |

--- a/components.yaml
+++ b/components.yaml
@@ -171,7 +171,7 @@ ACHEM:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.8.0
+  tag: v3.9.0
   develop: develop
 
 mom:
@@ -183,7 +183,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v3.7
+  tag: geos/v3.8
   develop: geos/main
   recurse_submodules: true
 

--- a/components.yaml
+++ b/components.yaml
@@ -171,7 +171,7 @@ ACHEM:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.7.1
+  tag: v3.8.0
   develop: develop
 
 mom:


### PR DESCRIPTION
This PR updates GEOS_OceanGridComp to v3.9.0. This has multiple fixes in the Ocean Grid Comp from @afahadabdullah, @sinakhani, @zhaobin74 and @adarmenov:

* v3: Magnitude of the surface stress passing into the MOM6 by @sinakhani in https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/115
* v3: Set MEKE_POSITIVE to True by @mathomp4 in https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/114
* v3: mit C180 LLC270 config by @afahadabdullah in https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/97
* v3 improve JRA55-DO runoff distribution and add Ice calving flux  by @zhaobin74 in https://github.com/GEOS-ESM/GEOS_OceanGridComp/pull/107

This also updates to use mom6 geos/v3.8 which has MOM6 as of 2026-Mar-03

This is *zero-diff* for the dataocean, but *non-zero-diff* for Coupled MOM6 runs.