### PR TITLE
v11: Update label enforcer with agcm and ogcm diff labels

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "0 diff agcm,non 0-diff agcm,0-diff structural,0-diff trivial,automatic,github_actions"
+          labels: "0-diff agcm,non-0-diff agcm,0-diff structural,0-diff trivial,automatic,github_actions"
           add_comment: true
           message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for uncoulped dataocean runs: {{ provided }}. Please add so that the PR can be merged."
 
@@ -27,7 +27,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "0 diff ogcm,non 0-diff ogcm,0-diff structural,0-diff trivial,automatic,github_actions"
+          labels: "0-diff ogcm,non-0-diff ogcm,0-diff structural,0-diff trivial,automatic,github_actions"
           add_comment: true
           message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for coupled mom6 runs: {{ provided }}. Please add so that the PR can be merged."
 
@@ -40,7 +40,7 @@ jobs:
         #with:
           #mode: minimum
           #count: 1
-          #labels: "0 diff dataatm,non 0-diff ogcm,0-diff structural,0-diff trivial,automatic,github_actions"
+          #labels: "0-diff dataatm,non-0-diff ogcm,0-diff structural,0-diff trivial,automatic,github_actions"
           #add_comment: true
           #message: "This PR is being prevented from merging because you have not added one of our required labels to say if they are 0-diff or non-0-diff for coupled dataatm mom6 runs: {{ provided }}. Please add so that the PR can be merged."
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,7 @@ jobs:
     with:
       compiler: ${{ matrix.compiler }}
       cmake-build-type: ${{ matrix.build-type }}
+      fail-fast: false
 
   spack_build:
     uses: GEOS-ESM/CI-workflows/.github/workflows/spack_gcc_build.yml@project/geosgcm


### PR DESCRIPTION
This PR updates the label enforcer to require labels for both agcm and ogcm zero-diff-ness.