### PR TITLE
v12: Migrate ExtData YAMLs from GOCART and ACHEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | [GMAO_perllib](https://github.com/GEOS-ESM/GMAO_perllib)                       | [v1.1.0](https://github.com/GEOS-ESM/GMAO_perllib/releases/tag/v1.1.0)                                |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v2.1.6](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v2.1.6)                                 |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.3.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.3.0)                                      |
+| [GOCART2G_ExtData](https://github.com/GEOS-ESM/GOCART2G_ExtData)               | [v1.0.0](https://github.com/GEOS-ESM/GOCART2G_ExtData/releases/tag/v1.0.0)                            |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | Repository                                                                     | Version                                                                                               |
 | ----------                                                                     | -------                                                                                               |
 | [ACHEM](https://github.com/GEOS-ESM/ACHEM)                                     | [v1.0.1](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.0.1)                                       |
+| [Aerosol_ExtData](https://github.com/GEOS-ESM/Aerosol_ExtData)                 | [v1.0.0](https://github.com/GEOS-ESM/Aerosol_ExtData/releases/tag/v1.0.0)                            |
 | [CARMA](https://github.com/GEOS-ESM/CARMA)                                     | [v1.1.0](https://github.com/GEOS-ESM/CARMA/releases/tag/v1.1.0)                                       |
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
@@ -35,7 +36,6 @@
 | [GMAO_perllib](https://github.com/GEOS-ESM/GMAO_perllib)                       | [v1.1.0](https://github.com/GEOS-ESM/GMAO_perllib/releases/tag/v1.1.0)                                |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v2.1.6](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v2.1.6)                                 |
 | [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.3.0](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.3.0)                                      |
-| [GOCART2G_ExtData](https://github.com/GEOS-ESM/GOCART2G_ExtData)               | [v1.0.0](https://github.com/GEOS-ESM/GOCART2G_ExtData/releases/tag/v1.0.0)                            |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |

--- a/components.yaml
+++ b/components.yaml
@@ -105,8 +105,16 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: GCMv12-rc25
-  develop: feature/sdrabenh/gcm_v12
+  #tag: GCMv12-rc25
+  branch: feature/v12-move-extdata-yaml
+  develop: develop
+
+GOCART2G_ExtData:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART2G_ExtData
+  remote: ../GOCART2G_ExtData.git
+  #tag: GCMv12-rc25
+  branch: feature/v12-move-extdata-yaml
+  develop: develop
 
 QuickChem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@QuickChem

--- a/components.yaml
+++ b/components.yaml
@@ -87,7 +87,8 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: GCMv12-rc25
+  #tag: GCMv12-rc25
+  branch: feature/v12-move-extdata-yaml
   develop: feature/sdrabenh/gcm_v12
 
 HEMCO:

--- a/components.yaml
+++ b/components.yaml
@@ -174,7 +174,8 @@ GAAS:
 ACHEM:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@ACHEM
   remote: ../ACHEM.git
-  tag: v1.0.1
+  #tag: v1.0.1
+  branch: feature/v12-move-extdata-yaml
   develop: develop
 
 GEOS_OceanGridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -110,9 +110,9 @@ GOCART:
   branch: feature/v12-move-extdata-yaml
   develop: develop
 
-GOCART2G_ExtData:
-  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART2G_ExtData
-  remote: ../GOCART2G_ExtData.git
+Aerosol_ExtData:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@Aerosol_ExtData
+  remote: ../Aerosol_ExtData.git
   #tag: GCMv12-rc25
   branch: feature/v12-move-extdata-yaml
   develop: develop


### PR DESCRIPTION
# NOTE NOTE NOTE

This needs to be re-done/updated. GEOSgcm now will be using QFED3, see #1030 and #1029 

---

This PR migrates the GOCART2G and ACHEM ExtData YAML files from the GOCART repo to the new Aerosol_ExtData repo.

These files are based on those in [GOCART v2.6.2](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.6.2) (aka GOCART `develop` as of 2026-Mar-17) and [ACHEM v1.0.1](https://github.com/GEOS-ESM/ACHEM/releases/tag/v1.0.1)

So, this is essentially based on GEOSgcm v12

This to fully use this PR, changes are needed in:

* GEOSgcm: https://github.com/GEOS-ESM/GEOSgcm/pull/1046
* GEOSchem_GridComp: https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/312
* GOCART: https://github.com/GEOS-ESM/GOCART/pull/395
* Aerosol_ExtData: https://github.com/GEOS-ESM/Aerosol_ExtData/pull/1
* ACHEM: https://github.com/GEOS-ESM/ACHEM/pull/11

All are on the `feature/v12-move-extdata-yaml` branch.

Testing shows these changes are zero-diff to GEOSgcm v12 with GOCART v2.6.2 (see https://github.com/GEOS-ESM/GEOSgcm/pull/1030). It will of course be non-zero-diff to older v12 models.

Obviously, this will need tags in all the non-fixture repos.