### PR TITLE
v11: Update to ESMA_env v5.19.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
 
 # Anchors to prevent forgetting to update a version
 os_version: &os_version ubuntu24
-baselibs_version: &baselibs_version v8.24.0
+baselibs_version: &baselibs_version v8.27.0
 bcs_version: &bcs_version v11.6.0
 tag_build_arg_name: &tag_build_arg_name gcmversion
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                         |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.16.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.16.1)                    |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.74.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.74.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.18.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.18.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.19.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.19.0)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.11](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.11) |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v1.4.0](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv1.4.0)                         |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.16.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.16.1)                    |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v3.74.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v3.74.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.19.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.19.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.19.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.19.1)                                  |
 | [FMS](https://github.com/GEOS-ESM/FMS)                                         | [geos/2019.01.02+noaff.11](https://github.com/GEOS-ESM/FMS/releases/tag/geos%2F2019.01.02%2Bnoaff.11) |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.18.0
+  tag: v5.19.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.19.0
+  tag: v5.19.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates v11 to use ESMA_env v5.19.1 which has Baselibs 8.27.0. This has updates to ESMF and GFE.

Zero-diff.