### PR TITLE
v12: Update ESMA_env to 5.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v3.13.1](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv3.13.1)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.35.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.35.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.20.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.20.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.21.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.21.0)                                  |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.16.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.16.1)                    |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v3.13.1](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv3.13.1)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.35.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.35.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.19.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.19.1)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.20.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.20.0)                                  |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v2.16.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v2.16.1)                    |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.0.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.0.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.20.0
+  tag: v5.21.0
   develop: main
 
 cmake:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.19.1
+  tag: v5.20.0
   develop: main
 
 cmake:


### PR DESCRIPTION
This PR updates ESMA_env to v5.20.0. This has an update to `build.csh` → `parallel_build.csh` so that sensible defaults are chosen at NAS based on front-end:

  - `pfe*` → Rome (`rom_ait`)
  - `afe*` → Milan (`mil_ait`)
  - `athfe*` → Turin (`tur_ath`)


It also has updates needed for DSL work (not enabled by default)

