### PR TITLE
Uptick CHEM to v1.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ cmake --build build -j N
 cmake --install build
 ```
 
-where `N` is the number of parallel processes. On discover head nodes, this should only be as high as 2 due to limits on the head nodes. On a compute node, you can set `N` has high as you like, though 8-12 is about the limit of parallelism in our model's make system.
+where `N` is the number of parallel processes. On discover login nodes, this should only be as high as 2 due to limits on the login nodes. On a compute node, you can set `N` has high as you like, though 8-12 is about the limit of parallelism in our model's make system.
 
 ### Run the GCM
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
 | [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v2.9.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v2.9.0)                          |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v2.1.12](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v2.1.12)                                 |
-| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.16.1](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.16.1)                         |
+| [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v1.16.2](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v1.16.2)                         |
 | [GEOSgcm_App](https://github.com/GEOS-ESM/GEOSgcm_App)                         | [v2.3.15](https://github.com/GEOS-ESM/GEOSgcm_App/releases/tag/v2.3.15)                               |
 | [GEOSgcm_GridComp](https://github.com/GEOS-ESM/GEOSgcm_GridComp)               | [v2.8.1](https://github.com/GEOS-ESM/GEOSgcm_GridComp/releases/tag/v2.8.1)                            |
 | [GEOSradiation_GridComp](https://github.com/GEOS-ESM/GEOSradiation_GridComp)   | [v1.12.0](https://github.com/GEOS-ESM/GEOSradiation_GridComp/releases/tag/v1.12.0)                    |

--- a/components.yaml
+++ b/components.yaml
@@ -87,7 +87,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.16.1
+  tag: v1.16.2
   develop: develop
 
 HEMCO:


### PR DESCRIPTION
The latest release of GEOSchem_GridComp is zero-diff to the previous release.
It includes a new optional version of the Chem_Settling routine under Chem_Shared.
It also adds connectivity from GMI to GOCART2G.