### PR TITLE
Deactivate non-ported components on release/MAPL-v3

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(Shared)
 add_subdirectory(Components)
-add_subdirectory(Applications)
-add_subdirectory(FoundationModels)
+# add_subdirectory(Applications)     # not yet ported to MAPL3 - restore when ported
+# add_subdirectory(FoundationModels) # not yet ported to MAPL3 - restore when ported

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,6 +1,6 @@
 esma_add_subdirectories (
   GMAO_Shared
-  # NCEP_Shared  # not yet ported to MAPL3 - restore when ported
+  NCEP_Shared
   )
 
 if (NOT MAPL_FOUND)

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,6 +1,8 @@
+# not yet ported to MAPL3 - restore when GEOS_Shared (and dependents) are ported
+# GMAO_Shared is included but restricted to HERMES_LIGHT (GMAO_mpeu + minimal GMAO_hermes)
+# NCEP_Shared is NOT needed without the full GMAO_Shared/GMAO_transf cascade
 esma_add_subdirectories (
   GMAO_Shared
-  NCEP_Shared
   )
 
 if (NOT MAPL_FOUND)

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,6 +1,6 @@
 esma_add_subdirectories (
-  GMAO_Shared
-  NCEP_Shared
+  # GMAO_Shared  # not yet ported to MAPL3 - restore when ported
+  # NCEP_Shared  # not yet ported to MAPL3 - restore when ported
   )
 
 if (NOT MAPL_FOUND)

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 esma_add_subdirectories (
-  # GMAO_Shared  # not yet ported to MAPL3 - restore when ported
+  GMAO_Shared
   # NCEP_Shared  # not yet ported to MAPL3 - restore when ported
   )
 


### PR DESCRIPTION
## Summary

- `src/CMakeLists.txt`: comments out `Applications` and `FoundationModels`
- `src/Shared/CMakeLists.txt`: builds only `GMAO_Shared` (restricted to HERMES_LIGHT); comments out `NCEP_Shared`

## Context

Fixture-level changes to support the MAPL3 flip. The minimum `GMAO_Shared` build (GMAO_mpeu + GMAO_hermes light + GEOS_Shared) is required by `FVdycoreCubed_GridComp`. All three ported component groups build successfully:
- `GEOSgwd_GridComp`
- `FVdycoreCubed_GridComp`
- `GOCART2G_GridComp` / `DU2G_GridComp` / `SS2G_GridComp`

Related PRs (merge these first, bottom-up):
- GEOS-ESM/GMAO_Shared#412
- GEOS-ESM/GOCART#402
- GEOS-ESM/GEOSchem_GridComp#314
- GEOS-ESM/GEOSgcm_GridComp#1360