### PR TITLE
v11: Switch CICE develop to geos/release/v0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -196,7 +196,10 @@ cice6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSseaice_GridComp/CICE_GEOSPlug/@cice6
   remote: ../CICE.git
   tag: geos/v0.2.0
-  develop: geos/develop
+  # GEOS currently is not in sync with mainline CICE development, so we point to a specific release branch for now.
+  # Once we are in sync with mainline CICE development, we can point to the develop branch.
+  #develop: geos/develop
+  develop: geos/release/v0
   ignore_submodules: true
 
 icepack:


### PR DESCRIPTION
This PR updates the `mepo develop` for cice6 so that it points to a branch based off of `geos/v0.2.0`.

We do this because `geos/develop` is now pointing to a further state of development from the main CICE-Consortium fork.

cc @zhaobin74