### PR TITLE
MAPL: Consolidate enums and introduce MAPL_ API constants (w/compat shim) [MAPL3] [:chart_with_upwards_trend: MAPL3, :zero: Diff]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* MAPL: Consolidated enums (StateItemAllocation, FieldBundleType_Flag) into the new `enums/` layer and introduced MAPL_ API constants for public use. A backwards-compatibility shim is included for this release, maintaining export of previous names/types; this shim will be removed in a future update. (See MAPL #4973)
+
 ## [11.8.1] - 2026-01-07
 
 ### Zero-diff to Previous Release: YES


### PR DESCRIPTION
## Summary
- Consolidated StateItemAllocation and FieldBundleType_Flag enums into the new enums/ layer of MAPL.
- Created new MAPL_-prefixed API exports for these enums in enums/API.F90, marking the beginning of MAPL public API migration.
- Installed a backwards-compatibility shim temporarily exporting previous (unprefixed) names and types to ensure all downstream clients continue to build.
- Updated CMake and internal source module usage accordingly.
- Updated GEOSgcm/CHANGELOG.md to record this transitional step.

**NOTE:**
- This is zero-diff for all client interfaces; no science impact expected.
- Compatibility shim will be removed in a follow-up PR after downstream dependencies are ready.

---
Resolves MAPL #4973, part of #4969.

## Labels
:chart_with_upwards_trend: MAPL3
:zero: Diff
