### PR TITLE
Updates for install-dir-in-experiment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,14 @@ install(
    DESTINATION ${CMAKE_INSTALL_PREFIX}
    )
 
+# Install a runtime manifest describing the installed executable/shared-library payload.
+# This should run late in the install so that bin/, lib/, and etc/ are already populated.
+install(SCRIPT "${ESMA_CMAKE_PATH}/esma_install_manifest.cmake")
+
 # Adds ability to tar source
 include (esma_cpack)
 
-# This installs a tarball of the source code
+# This installs a tarfile of the source code
 # in the installation directory.
 # MUST BE THE LAST CODE IN THIS FILE
 option(INSTALL_SOURCE_TARFILE "Create and install source tarfile" OFF)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v3.13.1](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv3.13.1)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.40.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.40.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.41.0)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.24.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.24.0)                                  |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v3.0.0](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v3.0.0)                      |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.1.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.1.0)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,8 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.40.0
+  branch: feature/experiment-install
+  #tag: v4.40.0
   develop: develop
 
 ecbuild:
@@ -242,7 +243,8 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v3.0.0
+  branch: feature/experiment-install
+  #tag: v3.0.0
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -11,8 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  branch: feature/experiment-install
-  #tag: v4.40.0
+  tag: v4.41.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This is part of a suite of PRs to try and change how we handle `GEOSgcm.x` in GEOS. The issue is that more and more of GEOS subcomponents are becoming shared object libraries instead of static. 

## Overall Problem

That means the old trick of "copy someone else's `GEOSgcm.x` to my experiment" might not work. Why? Well, in GEOSgcm v11.10+, the Moist GridComp (for example) is now a shared object library and so just copying `GEOSgcm.x` isn't enough to actually use that other person's Moist GC code.

## What we change here 

In this repo we call a new cmake script that runs after `install`. It creates a "manifest" as it were. So, if a user has two experiments, you can compare the manifests that will be in the install to see what might have changed (not perfect, but better than nothing). For example, if you diff two manifests:

```
> diff installdir-v12-2026Jun23-1day-c48/install/GEOS_RUNTIME_MANIFEST.sha256 installdir-v12-2026Jun23-1day-c48-ChangeMoist-Try3/install/GEOS_RUNTIME_MANIFEST.sha256
190c190
< 01082779e76498ec996b15f7b06acd300384d7bb62b58091977c5204d1c14de1  9482728  lib/libGEOSmoist_GridComp.so
---
> b5f1b1ee19c614bf071f1d9004eec62dfcb1e021dc2a47ae2f0f1509d1bbf713  9482728  lib/libGEOSmoist_GridComp.so
```


