### PR TITLE
Update to MAPL 2.70.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if (NOT Baselibs_FOUND)
     target_link_libraries(FMS::fms_r8 INTERFACE ${LIBYAML_LIBRARIES})
   endif ()
 
-  find_package(MAPL 2.69 QUIET)
+  find_package(MAPL 2.70 QUIET)
   if (MAPL_FOUND)
     message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
   endif ()

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.69.1](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.69.1)                                      |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.70.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.70.0)                                      |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -50,7 +50,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.69.1
+  tag: v2.70.0
   develop: release/v2
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This PR updates to [MAPL v2.70.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.70.0). This release has a couple fixes. The one that matters most to GEOSgcm is a fix for ExtData for systems where the complete emissions set are not available.

Zero-diff.