### PR TITLE
Update to topo geos/v2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | [RRTMGP](https://github.com/GEOS-ESM/rte-rrtmgp)                               | [geos/v1.7+1.0.0](https://github.com/GEOS-ESM/rte-rrtmgp/releases/tag/geos%2Fv1.7%2B1.0.0)            |
 | [SIS2](https://github.com/GEOS-ESM/SIS2)                                       | [geos/v0.0.1](https://github.com/GEOS-ESM/SIS2/releases/tag/geos%2Fv0.0.1)                            |
 | [StratChem](https://github.com/GEOS-ESM/StratChem)                             | [v1.1.0](https://github.com/GEOS-ESM/StratChem/releases/tag/v1.1.0)                                   |
-| [Topo](https://github.com/GEOS-ESM/Topo)                                       | [geos/v2.1.0](https://github.com/GEOS-ESM/Topo/releases/tag/geos%2Fv2.1.0)                            |
+| [Topo](https://github.com/GEOS-ESM/Topo)                                       | [geos/v2.2.1](https://github.com/GEOS-ESM/Topo/releases/tag/geos%2Fv2.2.1)                            |
 | [TR](https://github.com/GEOS-ESM/TR)                                           | [v1.2.1](https://github.com/GEOS-ESM/TR/releases/tag/v1.2.1)                                          |
 | [UMD_Etc](https://github.com/GEOS-ESM/UMD_Etc)                                 | [v1.5.0](https://github.com/GEOS-ESM/UMD_Etc/releases/tag/v1.5.0)                                     |
 | [WW3](https://github.com/GEOS-ESM/WW3)                                         | [v7.14-geos-r1](https://github.com/GEOS-ESM/WW3/releases/tag/v7.14-geos-r1)                           |

--- a/components.yaml
+++ b/components.yaml
@@ -260,7 +260,7 @@ CPLFCST_Etc:
 Topo:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSsurface_GridComp/Utils/Raster/preproc/topography/@ncar_topo
   remote: ../Topo.git
-  tag: geos/v2.1.0
+  tag: geos/v2.2.1
   develop: geos
   blobless: true
 


### PR DESCRIPTION
Recently, in my testing for Flang, I needed an update to topo. @biljanaorescanin merged my fix and I released geos/v2.2.1

But I saw that topo in GEOSgcm was still at geos/v2.1.0 meaning we didn't take in geos/v2.2.0 (see https://github.com/GEOS-ESM/Topo/releases/tag/geos%2Fv2.2.0).

I'm making this PR and asking @biljanaorescanin to approve/deny if we want to move. I mean, I assume we do!