### PR TITLE
Uptick for CFv2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased
+
+## 2026-07-20
+* Update default configuration (HISTORY, GEOS-Chem setup) --  Tag v10.23.0+CFv2.0.1
+
 ## 2024-12-23
 * Updates to build scripts and experiment setup scripts
 

--- a/components.yaml
+++ b/components.yaml
@@ -67,7 +67,7 @@ fvdycore:
 GEOSchem_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp
   remote: ../GEOSchem_GridComp.git
-  tag: v1.10.2+CFv2.0.0
+  tag: v1.10.2+CFv2.0.1
   develop: develop
 
 HEMCO:
@@ -79,7 +79,7 @@ HEMCO:
 geos-chem:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/GEOSCHEMchem_GridComp/@geos-chem
   remote: ../geos-chem.git
-  tag: geos/v14.0.0+CFv2.0.0
+  tag: geos/v14.0.0+CFv2.0.1
   develop: geos/develop
 
 GOCART:
@@ -142,7 +142,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.8.0+CFv2.0.0
+  tag: v1.8.0+CFv2.0.1
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
Changes in the default setup for GEOS-Chem, and the HISTORY template, in preparation for tag v10.23.0+CFv2.0.1

As with recent changes to feature/geoscf/main, this PR has bypassed feature/geoscf/develop.
That branch includes changes to GEOSchem_GridComp, geos-chem and HEMCO, which should be revisited.