### PR TITLE
Update to mom6 geos/v3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |
-| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.8](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.8)                                          |
+| [MOM6](https://github.com/GEOS-ESM/MOM6)                                       | [geos/v3.9](https://github.com/GEOS-ESM/MOM6/tree/geos/v3.9)                                          |
 | [NCEP_Shared](https://github.com/GEOS-ESM/NCEP_Shared)                         | [v1.5.0](https://github.com/GEOS-ESM/NCEP_Shared/releases/tag/v1.5.0)                                 |
 | [QuickChem](https://github.com/GEOS-ESM/QuickChem)                             | [v1.0.0](https://github.com/GEOS-ESM/QuickChem/releases/tag/v1.0.0)                                   |
 | [RRG](https://github.com/GEOS-ESM/RRG)                                         | [v1.1.0](https://github.com/GEOS-ESM/RRG/releases/tag/v1.1.0)                                         |

--- a/components.yaml
+++ b/components.yaml
@@ -183,7 +183,7 @@ mom:
 mom6:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp/MOM6_GEOSPlug/@mom6
   remote: ../MOM6.git
-  tag: geos/v3.8
+  tag: geos/v3.9
   develop: geos/main
   recurse_submodules: true
 


### PR DESCRIPTION
This PR updates GEOSgcm to use mom6 geos/v3.9 which has the latest stable code from upstream.

Zero-diff for GEOS uses.