### PR TITLE
CMake Fixes for Spack builds of GEOS

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/auto_pr_to_mapl3.md
@@ -1,4 +1,4 @@
-## :memo:  Automatic PR: `main` → `release-v11/MAPL-v3`
+## :memo:  Automatic PR: `main` → `release/MAPL-v3`
 
 ### Description
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,61 +46,6 @@ find_package(MPI)
 
 include (esma)
 
-# Add CMake for when not using Baselibs
-if (NOT Baselibs_FOUND)
-
-  find_package(NetCDF REQUIRED C Fortran)
-  add_definitions(-DHAS_NETCDF4)
-  add_definitions(-DHAS_NETCDF3)
-  add_definitions(-DNETCDF_NEED_NF_MPIIO)
-  add_definitions(-DHAS_NETCDF3)
-
-  find_package(HDF5 REQUIRED)
-  if(HDF5_IS_PARALLEL)
-     add_definitions(-DH5_HAVE_PARALLEL)
-  endif()
-
-  if (NOT TARGET ESMF::ESMF)
-    find_package(ESMF 8.6.1 MODULE REQUIRED)
-    target_link_libraries(ESMF::ESMF INTERFACE MPI::MPI_Fortran)
-
-    # GEOS uses lowercase target due to historical reasons but
-    # the latest FindESMF.cmake file from ESMF produces an ESMF::ESMF target.
-    if (NOT TARGET esmf)
-      add_library(esmf ALIAS ESMF::ESMF)
-    endif ()
-    if (NOT TARGET ESMF)
-      add_library(ESMF ALIAS ESMF::ESMF)
-    endif ()
-  endif ()
-
-  find_package(GFTL_SHARED REQUIRED)
-
-  find_package(ZLIB REQUIRED)
-  # Another issue with historical reasons, old/wrong zlib target used in GEOS
-  add_library(ZLIB::zlib ALIAS ZLIB::ZLIB)
-
-  find_package(FMS REQUIRED COMPONENTS R4 R8)
-
-  # At the moment, there is no way to know if FMS was built with YAML
-  # so we need to rely on the user to set this option.
-  option(FMS_BUILT_WITH_YAML "FMS was built with YAML" OFF)
-  if (FMS_BUILT_WITH_YAML)
-    # We use the same Findlibyaml.cmake that FMS uses
-    find_package(libyaml REQUIRED)
-    message(STATUS "LIBYAML_INCLUDE_DIR: ${LIBYAML_INCLUDE_DIR}")
-    message(STATUS "LIBYAML_LIBRARIES: ${LIBYAML_LIBRARIES}")
-    target_link_libraries(FMS::fms_r4 INTERFACE ${LIBYAML_LIBRARIES})
-    target_link_libraries(FMS::fms_r8 INTERFACE ${LIBYAML_LIBRARIES})
-  endif ()
-
-  find_package(MAPL 2.70 QUIET)
-  if (MAPL_FOUND)
-    message(STATUS "Found MAPL: ${MAPL_BASE_DIR} (found version \"${MAPL_VERSION})\"")
-  endif ()
-
-endif ()
-
 ecbuild_declare_project()
 
 # Generic definitions

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | [CICE](https://github.com/GEOS-ESM/CICE)                                       | [geos/v0.2.0](https://github.com/GEOS-ESM/CICE/releases/tag/geos%2Fv0.2.0)                            |
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v3.13.1](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv3.13.1)                       |
-| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.41.0)                                |
+| [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.43.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.43.0)                                |
 | [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.25.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.25.0)                                  |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v3.0.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v3.0.1)                      |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.1.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.1.0)                                        |

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,8 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v4.41.0
+  #tag: v4.43.0
+  branch: feature/v4-external-libs
   develop: develop
 
 ecbuild:

--- a/components.yaml
+++ b/components.yaml
@@ -11,8 +11,7 @@ env:
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  #tag: v4.43.0
-  branch: feature/v4-external-libs
+  tag: v4.43.0
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR updates GEOSgcm to ESMA_cmake v4.43.0 which has various fixes found in Spack testing. Mainly how CMake handles libraries detection with both Baselibs and Spack.

All tests show this is zero-diff.