### PR TITLE
Fixes for NAS and Bash module switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 | [CPLFCST_Etc](https://github.com/GEOS-ESM/CPLFCST_Etc)                         | [v1.0.1](https://github.com/GEOS-ESM/CPLFCST_Etc/releases/tag/v1.0.1)                                 |
 | [ecbuild](https://github.com/GEOS-ESM/ecbuild)                                 | [geos/v3.13.1](https://github.com/GEOS-ESM/ecbuild/releases/tag/geos%2Fv3.13.1)                       |
 | [ESMA_cmake](https://github.com/GEOS-ESM/ESMA_cmake)                           | [v4.41.0](https://github.com/GEOS-ESM/ESMA_cmake/releases/tag/v4.41.0)                                |
-| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.25.0](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.25.0)                                  |
+| [ESMA_env](https://github.com/GEOS-ESM/ESMA_env)                               | [v5.25.1](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v5.25.1)                                  |
 | [FVdycoreCubed_GridComp](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp)   | [v3.0.1](https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/releases/tag/v3.0.1)                      |
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.1.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.1.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSgcm:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v5.25.0
+  tag: v5.25.1
   develop: main
 
 cmake:


### PR DESCRIPTION
This update to ESMA_env v5.25.1 fixes a bug with module switching at NAS under bash.