### PR TITLE
Update to MAPL 2.71.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |
-| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.70.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.70.0)                                      |
+| [MAPL](https://github.com/GEOS-ESM/MAPL)                                       | [v2.71.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.71.0)                                      |
 | [MATRIX](https://github.com/GEOS-ESM/MATRIX)                                   | [v1.0.0](https://github.com/GEOS-ESM/MATRIX/releases/tag/v1.0.0)                                      |
 | [MITgcm](https://github.com/GEOS-ESM/MITgcm)                                   | [checkpoint68o](https://github.com/GEOS-ESM/MITgcm/releases/tag/checkpoint68o)                        |
 | [MOM5](https://github.com/GEOS-ESM/MOM5)                                       | [geos/5.1.0+1.2.0](https://github.com/GEOS-ESM/MOM5/releases/tag/geos%2F5.1.0%2B1.2.0)                |

--- a/components.yaml
+++ b/components.yaml
@@ -45,8 +45,10 @@ GMAO_perllib:
   tag: v1.1.0
   develop: main
 
-# When updating the MAPL version, also update the MAPL version in the
-# CMakeLists.txt file for non-Baselibs builds
+# When updating the MAPL version, if it's a breaking
+# change, remember to update the MAPL version in
+# ESMA_cmake/external_libraries/ConfigureExternalLibraries.cmake
+# for MAPL-as-a-library builds
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git


### PR DESCRIPTION
This updates GEOSgcm to use MAPL v2.71.0. This has a few bug fixes for things in `time_ave_util.x` (from @bena-nasa) as well as fixes in the DSL Python bridge from @FlorianDeconinck .

All tests show it is zero-diff.