### PR TITLE
Update to GOCART v2.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | [GMI](https://github.com/GEOS-ESM/GMI)                                         | [v1.6.0](https://github.com/GEOS-ESM/GMI/releases/tag/v1.6.0)                                         |
 | [GMAO_perllib](https://github.com/GEOS-ESM/GMAO_perllib)                       | [v1.1.0](https://github.com/GEOS-ESM/GMAO_perllib/releases/tag/v1.1.0)                                |
 | [GMAO_Shared](https://github.com/GEOS-ESM/GMAO_Shared)                         | [v3.0.1](https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v3.0.1)                                 |
-| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.6.5](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.6.5)                                      |
+| [GOCART](https://github.com/GEOS-ESM/GOCART)                                   | [v2.6.6](https://github.com/GEOS-ESM/GOCART/releases/tag/v2.6.6)                                      |
 | [HEMCO](https://github.com/GEOS-ESM/HEMCO)                                     | [geos/v2.3.0](https://github.com/GEOS-ESM/HEMCO/releases/tag/geos%2Fv2.3.0)                           |
 | [Icepack](https://github.com/GEOS-ESM/Icepack)                                 | [geos/v0.3.0](https://github.com/GEOS-ESM/Icepack/releases/tag/geos%2Fv0.3.0)                         |
 | [MAM](https://github.com/GEOS-ESM/MAM)                                         | [v1.1.0](https://github.com/GEOS-ESM/MAM/releases/tag/v1.1.0)                                         |

--- a/components.yaml
+++ b/components.yaml
@@ -107,7 +107,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: v2.6.5
+  tag: v2.6.6
   develop: develop
 
 QuickChem:


### PR DESCRIPTION
This PR updates GEOSgcm to GOCART v2.6.6. This is identical to v2.6.5 except it has fixes to allow Intel `ifx` builds of GEOS to run with Ops emissions.

It is zero-diff for ifort and GNU.