### PR TITLE
Update to Ocean GC v3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.1.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.1.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
 | [GenCast-GEOS_FP](https://github.com/GEOS-ESM/GenCast_GEOS-FP)                 | [geos/v0.3.1](https://github.com/GEOS-ESM/GenCast_GEOS-FP/releases/tag/geos%2Fv0.3.1)                 |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.10.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.10.0)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.11.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.11.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v3.0.1](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v3.0.1)                                   |
 | [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/geos/v1.0.0)                   |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v2.0.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v2.0.0)                           |

--- a/components.yaml
+++ b/components.yaml
@@ -173,7 +173,7 @@ ACHEM:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.10.0
+  tag: v3.11.0
   develop: develop
 
 mom:


### PR DESCRIPTION
This updates to Ocean_GridComp v3.11.0.

This tag updates the MOM6 layouts for o720, o1440, and o2880. This does not affect other MOM6 oceans (o72 and o540)

To use these layouts with this tag, users should have the code from:

* https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1492
* https://github.com/GEOS-ESM/GEOSgcm_App/pull/910

These will soon be tagged but for now are in the `develop` branches of each.