### PR TITLE
Actually update to MAPL 2.71

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -52,7 +52,7 @@ GMAO_perllib:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.70.0
+  tag: v2.71.0
   develop: release/v2
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
So in #1120 I said "We update to MAPL 2.71" but I actually didn't change the freaking `components.yaml`. Oops.