### PR TITLE
Add LISF as mepo component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+
+* Registered `LISF` (NASA-LIS/LISF, `v7.8.0-public`) as a mepo component, vendored under `GEOSlis_GridComp/@LISF`.
 
 ## [11.10.1] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-* Registered `LISF` (NASA-LIS/LISF, `v7.8.0-public`) as a mepo component, vendored under `GEOSlis_GridComp/@LISF`.
+* Registered `LISF` (NASA-LIS/LISF, `v7.8.0-public`) as a mepo component, vendored under `LIS_GridComp/@LISF`.
 
 ## [11.10.1] - 2026-07-16
 

--- a/components.yaml
+++ b/components.yaml
@@ -273,7 +273,7 @@ GenCast_GEOS-FP:
   develop: geos/main
 
 LISF:
-  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSlis_GridComp/@LISF
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/LIS_GridComp/@LISF
   remote: https://github.com/NASA-LIS/LISF.git
   tag: v7.8.0-public
   develop: master

--- a/components.yaml
+++ b/components.yaml
@@ -272,3 +272,8 @@ GenCast_GEOS-FP:
   tag: geos/v0.3.1
   develop: geos/main
 
+LISF:
+  local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/GEOSlis_GridComp/@LISF
+  remote: https://github.com/NASA-LIS/LISF.git
+  tag: v7.8.0-public
+  develop: master

--- a/components.yaml
+++ b/components.yaml
@@ -58,7 +58,7 @@ MAPL:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v3.0.1
+  branch: feature/pchakrab/integrate-lis-into-v11
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: develop
 


### PR DESCRIPTION
> [!NOTE]  
> Not to be merged at the moment, here only for comparison purposes.

## Summary

Registers the vendored `@LISF` checkout (used by `GEOSlis_GridComp`) as a mepo component pointing at NASA-LIS/LISF, pinned to `v7.8.0-public`.