### PR TITLE
Update to Ocean GC v3.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | [GAAS](https://github.com/GEOS-ESM/GAAS)                                       | [v1.1.0](https://github.com/GEOS-ESM/GAAS/releases/tag/v1.1.0)                                        |
 | [geos-chem](https://github.com/GEOS-ESM/geos-chem)                             | [geos/v13.0.0-rc1](https://github.com/GEOS-ESM/geos-chem/releases/tag/geos%2Fv13.0.0-rc1)             |
 | [GenCast-GEOS_FP](https://github.com/GEOS-ESM/GenCast_GEOS-FP)                 | [geos/v0.3.1](https://github.com/GEOS-ESM/GenCast_GEOS-FP/releases/tag/geos%2Fv0.3.1)                 |
-| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.11.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.11.0)                        |
+| [GEOS_OceanGridComp](https://github.com/GEOS-ESM/GEOS_OceanGridComp)           | [v3.12.0](https://github.com/GEOS-ESM/GEOS_OceanGridComp/releases/tag/v3.12.0)                        |
 | [GEOS_Util](https://github.com/GEOS-ESM/GEOS_Util)                             | [v3.0.2](https://github.com/GEOS-ESM/GEOS_Util/releases/tag/v3.0.2)                                   |
 | [geos_state_bias](https://github.com/GEOS-ESM/geos_state_bias)                 | [geos/v1.0.0](https://github.com/GEOS-ESM/geos_state_bias/releases/tag/geos/v1.0.0)                   |
 | [GEOSchem_GridComp](https://github.com/GEOS-ESM/GEOSchem_GridComp)             | [v2.0.0](https://github.com/GEOS-ESM/GEOSchem_GridComp/releases/tag/v2.0.0)                           |

--- a/components.yaml
+++ b/components.yaml
@@ -173,7 +173,7 @@ ACHEM:
 GEOS_OceanGridComp:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/@GEOS_OceanGridComp
   remote: ../GEOS_OceanGridComp.git
-  tag: v3.11.0
+  tag: v3.12.0
   develop: develop
 
 mom:


### PR DESCRIPTION
This PR updates GEOSgcm to use Ocean GC v3.12.0.

This is part of a set of changes for better data atmosphere support from @zhaobin74 in reference to https://github.com/GEOS-ESM/GEOS_OceanGridComp/issues/127

As the Ocean GC part was essentially just a new file, this update is trivial for @sdrabenh to take whenever.

The second part of the change is in https://github.com/GEOS-ESM/GEOSgcm_App/pull/919


